### PR TITLE
Add utf8 encoding to all file opens for Windows compatibility

### DIFF
--- a/chainforge/app.py
+++ b/chainforge/app.py
@@ -46,7 +46,7 @@ def readCounts(data):
 
         # Open the temp file to read the progress so far:
         try: 
-            with open(tempfilepath, 'r') as f:
+            with open(tempfilepath, 'r', encoding='utf-8') as f:
                 queries = json.load(f)
         except FileNotFoundError as e:
              # If the temp file was deleted during executing, the Flask 'queryllm' func must've terminated successfully:

--- a/chainforge/flask_app.py
+++ b/chainforge/flask_app.py
@@ -338,7 +338,7 @@ def createProgressFile():
 
     # Create a scratch file for keeping track of how many responses loaded
     try:
-        with open(os.path.join(CACHE_DIR, f"_temp_{data['id']}.txt"), 'w') as f:
+        with open(os.path.join(CACHE_DIR, f"_temp_{data['id']}.txt"), 'w', encoding='utf-8') as f:
             json.dump({}, f)
         ret = jsonify({'success': True})
     except Exception as e:
@@ -428,13 +428,13 @@ async def queryLLM():
                 num_resps += len(response['responses'])
 
                 # Save the number of responses collected to a temp file on disk
-                with open(tempfilepath, 'r') as f:
+                with open(tempfilepath, 'r', encoding='utf-8') as f:
                     txt = f.read().strip()
                 
                 cur_data = json.loads(txt) if len(txt) > 0 else {}
                 cur_data[llm_str] = num_resps
                 
-                with open(tempfilepath, 'w') as f:
+                with open(tempfilepath, 'w', encoding='utf-8') as f:
                     json.dump(cur_data, f)
         except Exception as e:
             print(f'error generating responses for {llm}:', e)
@@ -467,7 +467,7 @@ async def queryLLM():
         os.remove(tempfilepath)
     
     # Save the responses *of this run* to the disk, for further recall:
-    with open(cache_filepath_last_run, "w") as f:
+    with open(cache_filepath_last_run, "w", encoding='utf-8') as f:
         json.dump(res, f)
 
     # Return all responses for all LLMs
@@ -574,7 +574,7 @@ def execute():
         all_evald_responses.extend(evald_responses)
 
     # Store the evaluated responses in a new cache json:
-    with open(cache_filepath, "w") as f:
+    with open(cache_filepath, "w", encoding='utf-8') as f:
         json.dump(all_evald_responses, f)
 
     ret = jsonify({'responses': all_evald_responses})
@@ -718,7 +718,7 @@ def importCache():
         
         # Write data to cache file
         # NOTE: This will overwrite any existing cache files with the same filename (id).
-        with open(cache_filepath, "w") as f:
+        with open(cache_filepath, "w", encoding='utf-8') as f:
             json.dump(data['files'][filename], f)
     
     print("Imported cache data and store to cache.")

--- a/chainforge/promptengine/query.py
+++ b/chainforge/promptengine/query.py
@@ -155,7 +155,7 @@ class PromptPipeline:
             return {}
     
     def _cache_responses(self, responses) -> None:
-        with open(self._filepath, "w") as f:
+        with open(self._filepath, "w", encoding='utf-8') as f:
             json.dump(responses, f)
     
     def clear_cached_responses(self) -> None:

--- a/chainforge/promptengine/utils.py
+++ b/chainforge/promptengine/utils.py
@@ -299,12 +299,12 @@ def create_dir_if_not_exists(path: str) -> None:
 
 def is_valid_filepath(filepath: str) -> bool:
     try:
-        with open(filepath, 'r'):
+        with open(filepath, 'r', encoding='utf-8'):
             pass
     except IOError:
         try:
             # Create the file if it doesn't exist, and write an empty json string to it
-            with open(filepath, 'w+') as f:
+            with open(filepath, 'w+', encoding='utf-8') as f:
                 f.write("{}")
                 pass
         except IOError:

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
 def readme():
-    with open('README.md') as f:
+    with open('README.md', encoding='utf-8') as f:
         return f.read()
 
 setup(
     name='chainforge',
-    version='0.1.2',
+    version='0.1.2.1',
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION
Windows is weird and assumes every file isn't unicode, while Linux and MacOS are 'with it' and assume the opposite:
https://stackoverflow.com/a/49562606/1911342

This adds `encoding='utf8'` to all file opens in the Python backend to fix Windows choking on parsing the `README.md`.