### PR TITLE
Refactor duplicate code

### DIFF
--- a/chainforge/react-server/src/JoinNode.js
+++ b/chainforge/react-server/src/JoinNode.js
@@ -8,14 +8,16 @@ import { IconArrowMerge, IconList } from '@tabler/icons-react';
 import { Divider, NativeSelect, Text, Popover, Tooltip, Center, Modal, Box } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { escapeBraces } from './backend/template';
-import { countNumLLMs, toStandardResponseFormat } from './backend/utils';
+import { countNumLLMs, toStandardResponseFormat, tagMetadataWithLLM, extractLLMLookup, removeLLMTagFromMetadata, truncStr, groupResponsesBy } from './backend/utils';
 import StorageCache from './backend/cache';
-import { formattingOptions } from './backend/utils';
-import { tagMetadataWithLLM } from './backend/utils';
-import { extractLLMLookup } from './backend/utils';
-import { removeLLMTagFromMetadata } from './backend/utils';
-import { truncStr } from './backend/utils';
-import { groupResponsesBy } from './backend/utils';
+
+const formattingOptions = [
+  {value: "\n\n", label:"double newline \\n\\n"},
+  {value: "\n",   label:"newline \\n"},
+  {value: "-",    label:"- dashed list"},
+  {value: "1.",    label:"1. numbered list"},
+  {value: "[]",   label:'["list", "of", "strings"]'}
+];
 
 const joinTexts = (texts, format) => {
   const escaped_texts = texts.map(t => escapeBraces(t));

--- a/chainforge/react-server/src/LLMResponseInspector.js
+++ b/chainforge/react-server/src/LLMResponseInspector.js
@@ -10,9 +10,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { IconTable, IconLayoutList } from '@tabler/icons-react';
 import * as XLSX from 'xlsx';
 import useStore from './store';
-import { filterDict } from './backend/utils';
-import { truncStr } from './backend/utils';
-import { groupResponsesBy } from './backend/utils';
+import { filterDict, truncStr, groupResponsesBy } from './backend/utils';
 
 // Helper funcs
 const countResponsesBy = (responses, keyFunc) => {

--- a/chainforge/react-server/src/LLMResponseInspector.js
+++ b/chainforge/react-server/src/LLMResponseInspector.js
@@ -11,27 +11,10 @@ import { IconTable, IconLayoutList } from '@tabler/icons-react';
 import * as XLSX from 'xlsx';
 import useStore from './store';
 import { filterDict } from './backend/utils';
+import { truncStr } from './backend/utils';
+import { groupResponsesBy } from './backend/utils';
 
 // Helper funcs
-const truncStr = (s, maxLen) => {
-  if (s.length > maxLen) // Cut the name short if it's long
-      return s.substring(0, maxLen) + '...'
-  else
-      return s;
-};
-const groupResponsesBy = (responses, keyFunc) => {
-  let responses_by_key = {};
-  let unspecified_group = [];
-  responses.forEach(item => {
-      const key = keyFunc(item);
-      const d = key !== null ? responses_by_key : unspecified_group;
-      if (key in d)
-          d[key].push(item);
-      else
-          d[key] = [item];
-  });
-  return [responses_by_key, unspecified_group];
-};
 const countResponsesBy = (responses, keyFunc) => {
   let responses_by_key = {};
   let unspecified_group = [];

--- a/chainforge/react-server/src/SplitNode.js
+++ b/chainforge/react-server/src/SplitNode.js
@@ -8,15 +8,19 @@ import { IconArrowMerge, IconArrowsSplit, IconList } from '@tabler/icons-react';
 import { Divider, NativeSelect, Text, Popover, Tooltip, Center, Modal, Box } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { escapeBraces } from './backend/template';
-import { processCSV, deepcopy, deepcopy_and_modify, dict_excluding_key, toStandardResponseFormat } from "./backend/utils";
+import { processCSV, deepcopy, deepcopy_and_modify, dict_excluding_key, toStandardResponseFormat, tagMetadataWithLLM, extractLLMLookup, removeLLMTagFromMetadata, truncStr } from "./backend/utils";
 
 import { fromMarkdown } from "mdast-util-from-markdown";
 import StorageCache from './backend/cache';
-import { formattingOptions } from './backend/utils';
-import { tagMetadataWithLLM } from './backend/utils';
-import { extractLLMLookup } from './backend/utils';
-import { removeLLMTagFromMetadata } from './backend/utils';
-import { truncStr } from './backend/utils';
+
+const formattingOptions = [
+  {value: "list",    label:"- list items"},
+  {value: "\n",   label:"newline \\n"},
+  {value: "\n\n", label:"double newline \\n\\n"},
+  {value: ",",    label:"commas (,)"},
+  {value: "code",  label:"code blocks"},
+  {value: "paragraph",  label:"paragraphs (md)"},
+];
 
 /** Flattens markdown AST as dict to text (string) */
 function compileTextFromMdAST(md) {

--- a/chainforge/react-server/src/SplitNode.js
+++ b/chainforge/react-server/src/SplitNode.js
@@ -12,51 +12,11 @@ import { processCSV, deepcopy, deepcopy_and_modify, dict_excluding_key, toStanda
 
 import { fromMarkdown } from "mdast-util-from-markdown";
 import StorageCache from './backend/cache';
-
-const formattingOptions = [
-  {value: "list",    label:"- list items"},
-  {value: "\n",   label:"newline \\n"},
-  {value: "\n\n", label:"double newline \\n\\n"},
-  {value: ",",    label:"commas (,)"},
-  {value: "code",  label:"code blocks"},
-  {value: "paragraph",  label:"paragraphs (md)"},
-];
-
-const truncStr = (s, maxLen) => {
-  if (s.length > maxLen) // Cut the name short if it's long
-      return s.substring(0, maxLen) + '...'
-  else
-      return s;
-};
-const tagMetadataWithLLM = (input_data) => {
-  let new_data = {};
-  Object.entries(input_data).forEach(([varname, resp_objs]) => {
-    new_data[varname] = resp_objs.map(r => {
-      if (!r || typeof r === 'string' || !r?.llm?.key) return r;
-      let r_copy = JSON.parse(JSON.stringify(r));
-      r_copy.metavars["__LLM_key"] = r.llm.key;
-      return r_copy;
-    });
-  });
-  return new_data;
-};
-const extractLLMLookup = (input_data) => {
-  let llm_lookup = {};
-  Object.entries(input_data).forEach(([varname, resp_objs]) => {
-    resp_objs.forEach(r => {
-      if (typeof r === 'string' || !r?.llm?.key || r.llm.key in llm_lookup) return;
-      llm_lookup[r.llm.key] = r.llm;
-    });
-  });
-  return llm_lookup;
-};
-const removeLLMTagFromMetadata = (metavars) => {
-  if (!('__LLM_key' in metavars))
-    return metavars; 
-  let mcopy = JSON.parse(JSON.stringify(metavars));
-  delete mcopy['__LLM_key'];
-  return mcopy;
-};
+import { formattingOptions } from './backend/utils';
+import { tagMetadataWithLLM } from './backend/utils';
+import { extractLLMLookup } from './backend/utils';
+import { removeLLMTagFromMetadata } from './backend/utils';
+import { truncStr } from './backend/utils';
 
 /** Flattens markdown AST as dict to text (string) */
 function compileTextFromMdAST(md) {

--- a/chainforge/react-server/src/VisNode.js
+++ b/chainforge/react-server/src/VisNode.js
@@ -7,15 +7,9 @@ import BaseNode from './BaseNode';
 import NodeLabel from './NodeLabelComponent';
 import PlotLegend from './PlotLegend';
 import fetch_from_backend from './fetch_from_backend';
+import { truncStr } from './backend/utils';
 
 // Helper funcs
-const truncStr = (s, maxLen) => {
-    if (s === undefined) return s;
-    if (s.length > maxLen) // Cut the name short if it's long
-        return s.substring(0, maxLen) + '...'
-    else
-        return s;
-}
 const splitAndAddBreaks = (s, chunkSize) => {
     // Split the input string into chunks of specified size
     let chunks = [];

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -1109,3 +1109,65 @@ export const browserTabIsActive = () => {
     return true;  // indeterminate
   }
 };
+
+export const formattingOptions = [
+  {value: "\n\n", label:"double newline \\n\\n"},
+  {value: "\n",   label:"newline \\n"},
+  {value: "-",    label:"- dashed list"},
+  {value: "1.",    label:"1. numbered list"},
+  {value: "[]",   label:'["list", "of", "strings"]'}
+];
+
+export const tagMetadataWithLLM = (input_data) => {
+  let new_data = {};
+  Object.entries(input_data).forEach(([varname, resp_objs]) => {
+    new_data[varname] = (resp_objs as any[]).map(r => {
+      if (!r || typeof r === 'string' || !r?.llm?.key) return r;
+      let r_copy = JSON.parse(JSON.stringify(r));
+      r_copy.metavars["__LLM_key"] = r.llm.key;
+      return r_copy;
+    });
+  });
+  return new_data;
+};
+
+export const extractLLMLookup = (input_data) => {
+  let llm_lookup = {};
+  Object.values(input_data).forEach((resp_objs) => {
+    (resp_objs as any[]).forEach(r => {
+      if (typeof r === 'string' || !r?.llm?.key || r.llm.key in llm_lookup) return;
+      llm_lookup[r.llm.key] = r.llm;
+    });
+  });
+  return llm_lookup;
+};
+
+export const removeLLMTagFromMetadata = (metavars) => {
+  if (!('__LLM_key' in metavars))
+    return metavars; 
+  let mcopy = JSON.parse(JSON.stringify(metavars));
+  delete mcopy['__LLM_key'];
+  return mcopy;
+};
+
+export const truncStr = (s, maxLen) => {
+  if (s === undefined) return s;
+  if (s.length > maxLen) // Cut the name short if it's long
+      return s.substring(0, maxLen) + '...';
+  else
+      return s;
+};
+
+export const groupResponsesBy = (responses, keyFunc) => {
+  let responses_by_key = {};
+  let unspecified_group = [];
+  responses.forEach(item => {
+      const key = keyFunc(item);
+      const d = key !== null ? responses_by_key : unspecified_group;
+      if (key in d)
+          d[key].push(item);
+      else
+          d[key] = [item];
+  });
+  return [responses_by_key, unspecified_group];
+};

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -1110,14 +1110,6 @@ export const browserTabIsActive = () => {
   }
 };
 
-export const formattingOptions = [
-  {value: "\n\n", label:"double newline \\n\\n"},
-  {value: "\n",   label:"newline \\n"},
-  {value: "-",    label:"- dashed list"},
-  {value: "1.",    label:"1. numbered list"},
-  {value: "[]",   label:'["list", "of", "strings"]'}
-];
-
 export const tagMetadataWithLLM = (input_data) => {
   let new_data = {};
   Object.entries(input_data).forEach(([varname, resp_objs]) => {


### PR DESCRIPTION
To address #166 , this commit refactor common constant helper functions used in React components JoinNode.js, LLMResponseInspector.js, SplitNode.js, and VisNode.js into utils.ts