### PR TITLE
Remove font to fix cursor accuracy in code editor

### DIFF
--- a/chainforge/react-server/src/index.css
+++ b/chainforge/react-server/src/index.css
@@ -8,7 +8,7 @@ body {
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
 


### PR DESCRIPTION
#64 raised an issue of mouse clicks not being accurate within the code editor.

https://github.com/ianarawjo/ChainForge/assets/77540029/b2775437-9e5c-45fe-a534-f609f2334a39

Ace can only display monospace fonts and source-code-pro isn’t a monospace font so I removed it from the css.

https://github.com/ianarawjo/ChainForge/assets/77540029/aa82d51a-71e0-4ec7-8406-397b311264c3

