### PR TITLE
Add Multi-Eval node

### DIFF
--- a/chainforge/react-server/src/App.tsx
+++ b/chainforge/react-server/src/App.tsx
@@ -29,6 +29,7 @@ import {
   IconArrowMerge,
   IconArrowsSplit,
   IconForms,
+  IconAbacus,
 } from "@tabler/icons-react";
 import RemoveEdge from "./RemoveEdge";
 import TextFieldsNode from "./TextFieldsNode"; // Import a custom node
@@ -88,6 +89,7 @@ import {
   isEdgeChromium,
   isChromium,
 } from "react-device-detect";
+import MultiEvalNode from "./MultiEvalNode";
 
 const IS_ACCEPTED_BROWSER =
   (isChrome ||
@@ -157,6 +159,7 @@ const nodeTypes = {
   simpleval: SimpleEvalNode,
   evaluator: CodeEvaluatorNode,
   llmeval: LLMEvaluatorNode,
+  multieval: MultiEvalNode,
   vis: VisNode,
   inspect: InspectNode,
   script: ScriptNode,
@@ -328,6 +331,7 @@ const App = () => {
   const addTabularDataNode = () => addNode("table");
   const addCommentNode = () => addNode("comment");
   const addLLMEvalNode = () => addNode("llmeval");
+  const addMultiEvalNode = () => addNode("multieval");
   const addJoinNode = () => addNode("join");
   const addSplitNode = () => addNode("split");
   const addProcessorNode = (progLang: string) => {
@@ -1050,6 +1054,15 @@ const App = () => {
                 >
                   {" "}
                   LLM Scorer{" "}
+                </Menu.Item>
+              </MenuTooltip>
+              <MenuTooltip label="Evaluate responses across multiple criteria (multiple code and/or LLM evaluators).">
+                <Menu.Item
+                  onClick={addMultiEvalNode}
+                  icon={<IconAbacus size="16px" />}
+                >
+                  {" "}
+                  Multi-Evaluator{" "}
                 </Menu.Item>
               </MenuTooltip>
               <Menu.Divider />

--- a/chainforge/react-server/src/CodeEvaluatorNode.tsx
+++ b/chainforge/react-server/src/CodeEvaluatorNode.tsx
@@ -235,8 +235,7 @@ export const CodeEvaluatorComponent = forwardRef<
     script_paths?: string[],
     runInSandbox?: boolean,
   ) => {
-    if (runInSandbox === undefined)
-      runInSandbox = sandbox;
+    if (runInSandbox === undefined) runInSandbox = sandbox;
 
     // Double-check that the code includes an 'evaluate' or 'process' function, whichever is needed:
     const find_func_regex =

--- a/chainforge/react-server/src/CodeEvaluatorNode.tsx
+++ b/chainforge/react-server/src/CodeEvaluatorNode.tsx
@@ -188,6 +188,7 @@ export interface CodeEvaluatorComponentProps {
   onCodeEdit?: (code: string) => void;
   onCodeChangedFromLastRun?: () => void;
   onCodeEqualToLastRun?: () => void;
+  sandbox?: boolean;
 }
 
 /**
@@ -206,6 +207,7 @@ export const CodeEvaluatorComponent = forwardRef<
     onCodeEdit,
     onCodeChangedFromLastRun,
     onCodeEqualToLastRun,
+    sandbox,
   },
   ref,
 ) {
@@ -233,6 +235,9 @@ export const CodeEvaluatorComponent = forwardRef<
     script_paths?: string[],
     runInSandbox?: boolean,
   ) => {
+    if (runInSandbox === undefined)
+      runInSandbox = sandbox;
+
     // Double-check that the code includes an 'evaluate' or 'process' function, whichever is needed:
     const find_func_regex =
       node_type === "evaluator"

--- a/chainforge/react-server/src/LLMEvalNode.tsx
+++ b/chainforge/react-server/src/LLMEvalNode.tsx
@@ -157,7 +157,7 @@ export const LLMEvaluatorComponent = forwardRef<
       " " +
       formatting_instr +
       "\n```\n{input}\n```";
-      const llm_key = llmScorers[0].key ?? "";
+    const llm_key = llmScorers[0].key ?? "";
 
     // Fetch info about the number of queries we'll need to make
     return grabResponses(input_node_ids)
@@ -171,11 +171,14 @@ export const LLMEvaluatorComponent = forwardRef<
         return onProgressChange
           ? (progress_by_llm: Dict<QueryProgress>) =>
               onProgressChange({
-                success: (100 * progress_by_llm[llm_key].success) / num_resps_required,
-                error: (100 * progress_by_llm[llm_key].error) / num_resps_required,
+                success:
+                  (100 * progress_by_llm[llm_key].success) / num_resps_required,
+                error:
+                  (100 * progress_by_llm[llm_key].error) / num_resps_required,
               })
           : undefined;
-      }).then((progress_listener) => {
+      })
+      .then((progress_listener) => {
         // Run LLM as evaluator
         return evalWithLLM(
           id ?? Date.now().toString(),
@@ -184,18 +187,19 @@ export const LLMEvaluatorComponent = forwardRef<
           input_node_ids,
           apiKeys ?? {},
           progress_listener,
-        )
-      }).then(function (res) {
-      // Check if there's an error; if so, bubble it up to user and exit:
-      if (res.errors && res.errors.length > 0) throw new Error(res.errors[0]);
-      else if (res.responses === undefined)
-        throw new Error(
-          "Unknown error encountered when requesting evaluations: empty response returned.",
         );
+      })
+      .then(function (res) {
+        // Check if there's an error; if so, bubble it up to user and exit:
+        if (res.errors && res.errors.length > 0) throw new Error(res.errors[0]);
+        else if (res.responses === undefined)
+          throw new Error(
+            "Unknown error encountered when requesting evaluations: empty response returned.",
+          );
 
-      // Success!
-      return res.responses;
-    });
+        // Success!
+        return res.responses;
+      });
   };
 
   // Export the current internal state as JSON

--- a/chainforge/react-server/src/LLMEvalNode.tsx
+++ b/chainforge/react-server/src/LLMEvalNode.tsx
@@ -21,7 +21,7 @@ import LLMResponseInspectorModal, {
 } from "./LLMResponseInspectorModal";
 import InspectFooter from "./InspectFooter";
 import LLMResponseInspectorDrawer from "./LLMResponseInspectorDrawer";
-import { stripLLMDetailsFromResponses } from "./backend/utils";
+import { genDebounceFunc, stripLLMDetailsFromResponses } from "./backend/utils";
 import { AlertModalContext } from "./AlertModal";
 import { Dict, LLMResponse, LLMSpec, QueryProgress } from "./backend/typing";
 import { Status } from "./StatusIndicatorComponent";
@@ -116,11 +116,18 @@ export const LLMEvaluatorComponent = forwardRef<
   );
   const apiKeys = useStore((state) => state.apiKeys);
 
+  // Debounce helpers
+  const debounceTimeoutRef = useRef(null);
+  const debounce = genDebounceFunc(debounceTimeoutRef);
+
   const handlePromptChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       // Store prompt text
       setPromptText(e.target.value);
-      if (onPromptEdit) onPromptEdit(e.target.value);
+
+      // Update the caller, but debounce to reduce the number of callbacks when user is typing
+      if (onPromptEdit) 
+        debounce(() => onPromptEdit(e.target.value), 200)();
     },
     [setPromptText, onPromptEdit],
   );

--- a/chainforge/react-server/src/LLMResponseInspector.tsx
+++ b/chainforge/react-server/src/LLMResponseInspector.tsx
@@ -747,7 +747,7 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
           const defaultOpened =
             !first_opened ||
             eatenvars.length === 0 ||
-            eatenvars[eatenvars.length - 1] === "LLM";
+            eatenvars[eatenvars.length - 1] === "$LLM";
           first_opened = true;
           leaf_id += 1;
           return (
@@ -771,13 +771,13 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
         // we also bucket any 'leftover' responses that didn't have the requested variable (a kind of 'soft fail')
         const group_name = varnames[0];
         const [grouped_resps, leftover_resps] =
-          group_name === "LLM"
+          group_name === "$LLM"
             ? groupResponsesBy(resps, getLLMName)
             : groupResponsesBy(resps, (r) =>
                 group_name in r.vars ? r.vars[group_name] : null,
               );
         const get_header =
-          group_name === "LLM"
+          group_name === "$LLM"
             ? (key: string, val?: string) => (
                 <div
                   key={val}
@@ -796,7 +796,7 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
         const defaultOpened =
           !first_opened ||
           eatenvars.length === 0 ||
-          eatenvars[eatenvars.length - 1] === "LLM";
+          eatenvars[eatenvars.length - 1] === "$LLM";
         const grouped_resps_divs = Object.keys(grouped_resps).map((g) =>
           groupByVars(
             grouped_resps[g],

--- a/chainforge/react-server/src/MultiEvalNode.tsx
+++ b/chainforge/react-server/src/MultiEvalNode.tsx
@@ -7,6 +7,7 @@ import React, {
   useContext,
 } from "react";
 import { Handle, Position } from "reactflow";
+import { v4 as uuid } from "uuid";
 import {
   TextInput,
   Text,
@@ -198,6 +199,7 @@ const EvaluatorContainer: React.FC<EvaluatorContainerProps> = ({
 
 export interface EvaluatorContainerDesc {
   name: string; // the user's nickname for the evaluator, which displays as the title of the banner
+  uid: string; // a unique identifier for this evaluator, since name can change
   type: "python" | "javascript" | "llm"; // the type of evaluator
   state: Dict; // the internal state necessary for that specific evaluator component (e.g., a prompt for llm eval, or code for code eval)
   progress?: QueryProgress;
@@ -262,7 +264,7 @@ const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
   // Add an evaluator to the end of the list
   const addEvaluator = useCallback(
     (name: string, type: EvaluatorContainerDesc["type"], state: Dict) => {
-      setEvaluators(evaluators.concat({ name, type, state }));
+      setEvaluators(evaluators.concat({ name, uid: uuid(), type, state }));
     },
     [setEvaluators, evaluators],
   );
@@ -708,7 +710,7 @@ const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
                     prompt={e.state?.prompt}
                     grader={e.state?.grader}
                     format={e.state?.format}
-                    id={id}
+                    id={`${id}-${e.uid}`}
                     showUserInstruction={false}
                     onPromptEdit={(prompt) =>
                       updateEvalState(idx, (e) => (e.state.prompt = prompt))

--- a/chainforge/react-server/src/MultiEvalNode.tsx
+++ b/chainforge/react-server/src/MultiEvalNode.tsx
@@ -1,0 +1,741 @@
+import React, {
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useContext,
+} from "react";
+import { Handle, Position } from "reactflow";
+import {
+  TextInput,
+  Text,
+  Group,
+  ActionIcon,
+  Menu,
+  Card,
+  rem,
+  Collapse,
+  Button,
+  Alert,
+  Flex,
+  Tooltip,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import {
+  IconAbacus,
+  IconChevronDown,
+  IconChevronRight,
+  IconDots,
+  IconInfoCircle,
+  IconPlus,
+  IconRobot,
+  IconSearch,
+  IconSparkles,
+  IconTerminal,
+  IconTrash,
+} from "@tabler/icons-react";
+import BaseNode from "./BaseNode";
+import NodeLabel from "./NodeLabelComponent";
+import InspectFooter from "./InspectFooter";
+import LLMResponseInspectorModal, {
+  LLMResponseInspectorModalRef,
+} from "./LLMResponseInspectorModal";
+import useStore from "./store";
+import {
+  APP_IS_RUNNING_LOCALLY,
+  batchResponsesByUID,
+  toStandardResponseFormat,
+} from "./backend/utils";
+import LLMResponseInspectorDrawer from "./LLMResponseInspectorDrawer";
+import {
+  CodeEvaluatorComponent,
+  CodeEvaluatorComponentRef,
+} from "./CodeEvaluatorNode";
+import { LLMEvaluatorComponent, LLMEvaluatorComponentRef } from "./LLMEvalNode";
+import { GatheringResponsesRingProgress } from "./LLMItemButtonGroup";
+import { Dict, LLMResponse, QueryProgress } from "./backend/typing";
+import { AlertModalContext } from "./AlertModal";
+import { Status } from "./StatusIndicatorComponent";
+
+const IS_RUNNING_LOCALLY = APP_IS_RUNNING_LOCALLY();
+
+const EVAL_TYPE_PRETTY_NAME = {
+  python: "Python",
+  javascript: "JavaScript",
+  llm: "LLM",
+};
+
+export interface EvaluatorContainerProps {
+  name: string;
+  type: string;
+  padding?: string | number;
+  onDelete: () => void;
+  onChangeTitle: (newTitle: string) => void;
+  progress?: QueryProgress;
+  children: React.ReactNode;
+}
+
+/** A wrapper for a single evaluator, that can be renamed */
+const EvaluatorContainer: React.FC<EvaluatorContainerProps> = ({
+  name,
+  type: evalType,
+  padding,
+  onDelete,
+  onChangeTitle,
+  progress,
+  children,
+}) => {
+  const [opened, { toggle }] = useDisclosure(false);
+  const _padding = useMemo(() => padding ?? "0px", [padding]);
+  const [title, setTitle] = useState(name ?? "Criteria");
+
+  const handleChangeTitle = (newTitle: string) => {
+    setTitle(newTitle);
+    if (onChangeTitle) onChangeTitle(newTitle);
+  };
+
+  return (
+    <Card
+      withBorder
+      shadow="sm"
+      mb="xs"
+      radius="md"
+      style={{ cursor: "default" }}
+    >
+      <Card.Section withBorder pl="8px">
+        <Group>
+          <Group spacing="0px">
+            <Button
+              onClick={toggle}
+              variant="subtle"
+              color="gray"
+              p="0px"
+              m="0px"
+            >
+              {opened ? (
+                <IconChevronDown size="14pt" />
+              ) : (
+                <IconChevronRight size="14pt" />
+              )}
+            </Button>
+            <TextInput
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onBlur={(e) => handleChangeTitle(e.target.value)}
+              placeholder="Criteria name"
+              variant="unstyled"
+              size="sm"
+              className="nodrag nowheel"
+              styles={{
+                input: {
+                  padding: "0px",
+                  height: "14pt",
+                  minHeight: "0pt",
+                  fontWeight: "bold",
+                },
+              }}
+            />
+          </Group>
+          <Group spacing="4px" ml="auto">
+            <Text color="#bbb" size="sm" mr="6px">
+              {evalType}
+            </Text>
+            {progress ? (
+              <GatheringResponsesRingProgress progress={progress} />
+            ) : (
+              <></>
+            )}
+            {/* <Progress
+                radius="xl"
+                w={32}
+                size={14}
+                sections={[
+                  { value: 70, color: 'green', tooltip: '70% true' },
+                  { value: 30, color: 'red', tooltip: '30% false' },
+                ]} /> */}
+            <Menu withinPortal position="right-start" shadow="sm">
+              <Menu.Target>
+                <ActionIcon variant="subtle" color="gray">
+                  <IconDots style={{ width: rem(16), height: rem(16) }} />
+                </ActionIcon>
+              </Menu.Target>
+
+              <Menu.Dropdown>
+                <Menu.Item icon={<IconSearch size="14px" />}>
+                  Inspect scores
+                </Menu.Item>
+                <Menu.Item icon={<IconInfoCircle size="14px" />}>
+                  Help / info
+                </Menu.Item>
+                <Menu.Item
+                  icon={<IconTrash size="14px" />}
+                  color="red"
+                  onClick={onDelete}
+                >
+                  Delete
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
+          </Group>
+        </Group>
+      </Card.Section>
+
+      <Card.Section p={opened ? _padding : "0px"}>
+        <Collapse in={opened}>{children}</Collapse>
+      </Card.Section>
+    </Card>
+  );
+};
+
+export interface EvaluatorContainerDesc {
+  name: string; // the user's nickname for the evaluator, which displays as the title of the banner
+  type: "python" | "javascript" | "llm"; // the type of evaluator
+  state: Dict; // the internal state necessary for that specific evaluator component (e.g., a prompt for llm eval, or code for code eval)
+  progress?: QueryProgress;
+}
+
+export interface MultiEvalNodeProps {
+  data: {
+    evaluators: EvaluatorContainerDesc[];
+    refresh: boolean;
+    title: string;
+  };
+  id: string;
+}
+
+/** A node that stores multiple evaluator functions (can be mix of LLM scorer prompts and arbitrary code.) */
+const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
+  const setDataPropsForNode = useStore((state) => state.setDataPropsForNode);
+  const pullInputData = useStore((state) => state.pullInputData);
+  const pingOutputNodes = useStore((state) => state.pingOutputNodes);
+  const bringNodeToFront = useStore((state) => state.bringNodeToFront);
+  const inputEdgesForNode = useStore((state) => state.inputEdgesForNode);
+
+  const flags = useStore((state) => state.flags);
+  const AI_SUPPORT_ENABLED = useMemo(() => {
+    return flags.aiSupport;
+  }, [flags]);
+
+  const [status, setStatus] = useState<Status>(Status.NONE);
+  // For displaying error messages to user
+  const showAlert = useContext(AlertModalContext);
+  const inspectModal = useRef<LLMResponseInspectorModalRef>(null);
+
+  // -- EvalGen access --
+  // const pickCriteriaModalRef = useRef(null);
+  // const onClickPickCriteria = () => {
+  //   const inputs = handlePullInputs();
+  //   pickCriteriaModalRef?.current?.trigger(inputs, (implementations: EvaluatorContainerDesc[]) => {
+  //     // Returned if/when the Pick Criteria modal finishes generating implementations.
+  //     console.warn(implementations);
+  //     // Append the returned implementations to the end of the existing eval list
+  //     setEvaluators((evs) => evs.concat(implementations));
+  //   });
+  // };
+
+  const [uninspectedResponses, setUninspectedResponses] = useState(false);
+  const [lastResponses, setLastResponses] = useState<LLMResponse[]>([]);
+  const [lastRunSuccess, setLastRunSuccess] = useState(true);
+  const [showDrawer, setShowDrawer] = useState(false);
+
+  /** Store evaluators as array of JSON serialized state:
+   * {  name: <string>  // the user's nickname for the evaluator, which displays as the title of the banner
+   *    type: 'python' | 'javascript' | 'llm'  // the type of evaluator
+   *    state: <dict>  // the internal state necessary for that specific evaluator component (e.g., a prompt for llm eval, or code for code eval)
+   * }
+   */
+  const [evaluators, setEvaluators] = useState(data.evaluators ?? []);
+
+  // Add an evaluator to the end of the list
+  const addEvaluator = useCallback(
+    (name: string, type: EvaluatorContainerDesc["type"], state: Dict) => {
+      setEvaluators(evaluators.concat({ name, type, state }));
+    },
+    [setEvaluators, evaluators],
+  );
+
+  // Sync evaluator state to stored state of this node
+  useEffect(() => {
+    setDataPropsForNode(id, { evaluators });
+  }, [evaluators]);
+
+  // Generate UI for the evaluator state
+  const evaluatorComponentRefs = useRef<
+    {
+      type: "code" | "llm";
+      name: string;
+      ref: CodeEvaluatorComponentRef | LLMEvaluatorComponentRef | null;
+    }[]
+  >([]);
+  const evaluatorComponents = useMemo(() => {
+    evaluatorComponentRefs.current = [];
+    const updateEvalState = (
+      idx: number,
+      transformFunc: (e: EvaluatorContainerDesc) => void,
+    ) =>
+      setEvaluators((es) =>
+        es.map((e, i) => {
+          if (idx === i) transformFunc(e);
+          return e;
+        }),
+      );
+    return evaluators.map((e, idx) => {
+      let component: React.ReactNode;
+      if (e.type === "python" || e.type === "javascript") {
+        component = (
+          <CodeEvaluatorComponent
+            ref={(el) =>
+              (evaluatorComponentRefs.current[idx] = {
+                type: "code",
+                name: e.name,
+                ref: el,
+              })
+            }
+            code={e.state?.code}
+            progLang={e.type}
+            type="evaluator"
+            id={id}
+            onCodeEdit={(code) =>
+              updateEvalState(idx, (e) => (e.state.code = code))
+            }
+            showUserInstruction={false}
+          />
+        );
+      } else if (e.type === "llm") {
+        component = (
+          <LLMEvaluatorComponent
+            ref={(el) =>
+              (evaluatorComponentRefs.current[idx] = {
+                type: "llm",
+                name: e.name,
+                ref: el,
+              })
+            }
+            prompt={e.state?.prompt}
+            grader={e.state?.grader}
+            format={e.state?.format}
+            id={id}
+            showUserInstruction={false}
+            onPromptEdit={(prompt) =>
+              updateEvalState(idx, (e) => (e.state.prompt = prompt))
+            }
+            onLLMGraderChange={(grader) =>
+              updateEvalState(idx, (e) => (e.state.grader = grader))
+            }
+            onFormatChange={(format) =>
+              updateEvalState(idx, (e) => (e.state.format = format))
+            }
+          />
+        );
+      } else {
+        console.error(
+          `Unknown evaluator type ${e.type} inside multi-evaluator node. Cannot display evaluator UI.`,
+        );
+        component = <Alert>Error: Unknown evaluator type {e.type}</Alert>;
+      }
+      return (
+        <EvaluatorContainer
+          name={e.name}
+          key={`${e.name}-${idx}`}
+          type={EVAL_TYPE_PRETTY_NAME[e.type]}
+          progress={e.progress}
+          onDelete={() => {
+            delete evaluatorComponentRefs.current[idx];
+            setEvaluators(evaluators.filter((_, i) => i !== idx));
+          }}
+          onChangeTitle={(newTitle) =>
+            setEvaluators(
+              evaluators.map((e, i) => {
+                if (i === idx) e.name = newTitle;
+                console.log(e);
+                return e;
+              }),
+            )
+          }
+          padding={e.type === "llm" ? "8px" : undefined}
+        >
+          {component}
+        </EvaluatorContainer>
+      );
+    });
+  }, [evaluators, id]);
+
+  const handleError = useCallback(
+    (err: Error | string) => {
+      console.error(err);
+      setStatus(Status.ERROR);
+      showAlert && showAlert(err);
+    },
+    [showAlert, setStatus],
+  );
+
+  const handlePullInputs = useCallback(() => {
+    // Pull input data
+    try {
+      const pulled_inputs = pullInputData(["responseBatch"], id);
+      if (!pulled_inputs || !pulled_inputs.responseBatch) {
+        console.warn(`No inputs to the Multi-Evaluator node.`);
+        return [];
+      }
+      // Convert to standard response format (StandardLLMResponseFormat)
+      return pulled_inputs.responseBatch.map(toStandardResponseFormat);
+    } catch (err) {
+      handleError(err as Error);
+      return [];
+    }
+  }, [pullInputData, id, toStandardResponseFormat]);
+
+  const handleRunClick = useCallback(() => {
+    // Pull inputs to the node
+    const pulled_inputs = handlePullInputs();
+    if (!pulled_inputs || pulled_inputs.length === 0) return;
+
+    // Get the ids from the connected input nodes:
+    // TODO: Remove this dependency; have everything go through pull instead.
+    const input_node_ids = inputEdgesForNode(id).map((e) => e.source);
+    if (input_node_ids.length === 0) {
+      console.warn("No inputs to multi-evaluator node.");
+      return;
+    }
+
+    // Sanity check that there's evaluators in the multieval node
+    if (
+      !evaluatorComponentRefs.current ||
+      evaluatorComponentRefs.current.length === 0
+    ) {
+      console.error("Cannot run multievals: No current evaluators found.");
+      return;
+    }
+
+    // Set status and created rejection callback
+    setStatus(Status.LOADING);
+    setLastResponses([]);
+
+    // Helper function to update progress ring on a single evaluator component
+    const updateProgressRing = (
+      evaluator_idx: number,
+      progress?: QueryProgress,
+    ) => {
+      setEvaluators((evs) => {
+        if (evs.length >= evaluator_idx) return evs;
+        evs[evaluator_idx].progress = progress;
+        return [...evs];
+      });
+    };
+
+    // Run all evaluators here!
+    // TODO
+    const runPromises = evaluatorComponentRefs.current.map(
+      ({ type, name, ref }, idx) => {
+        if (ref === null) return { type: "error", name, result: null };
+
+        // Start loading spinner status on running evaluators
+        updateProgressRing(idx, { success: 0, error: 0 });
+
+        // Run each evaluator
+        if (type === "code") {
+          // Run code evaluator
+          // TODO: Change runInSandbox to be user-controlled, for Python code evals (right now it is always sandboxed)
+          return (ref as CodeEvaluatorComponentRef)
+            .run(pulled_inputs, undefined, true)
+            .then((ret) => {
+              console.log("Code evaluator done!", ret);
+              updateProgressRing(idx, undefined);
+              if (ret.error !== undefined) throw new Error(ret.error);
+              return {
+                type: "code",
+                name,
+                result: ret.responses,
+              };
+            });
+        } else {
+          // Run LLM-based evaluator
+          // TODO: Add back live progress, e.g. (progress) => updateProgressRing(idx, progress)) but with appropriate mapping for progress.
+          return (ref as LLMEvaluatorComponentRef)
+            .run(input_node_ids, () => {
+              /** skip live progress updates for now */
+            })
+            .then((ret) => {
+              console.log("LLM evaluator done!", ret);
+              updateProgressRing(idx, undefined);
+              return {
+                type: "llm",
+                name,
+                result: ret,
+              };
+            });
+        }
+      },
+    );
+
+    // When all evaluators finish...
+    Promise.allSettled(runPromises).then((settled) => {
+      if (settled.some((s) => s.status === "rejected")) {
+        setStatus(Status.ERROR);
+        setLastRunSuccess(false);
+        // @ts-expect-error Reason exists on rejected settled promises, but TS doesn't know it for some reason.
+        handleError(settled.find((s) => s.status === "rejected").reason);
+        return;
+      }
+
+      // Ignore null refs
+      settled = settled.filter(
+        (s) => s.status === "fulfilled" && s.value.result !== null,
+      );
+
+      // Success -- set the responses for the inspector
+      // First we need to group up all response evals by UID, *within* each evaluator.
+      const evalResults = settled.map((s) => {
+        const v =
+          s.status === "fulfilled"
+            ? s.value
+            : { type: "code", name: "Undefined", result: [] };
+        if (v.type === "llm") return v; // responses are already batched by uid
+        // If code evaluator, for some reason, in this version of CF the code eval has de-batched responses.
+        // We need to re-batch them by UID before returning, to correct this:
+        return {
+          type: v.type,
+          name: v.name,
+          result: batchResponsesByUID(v.result ?? []),
+        };
+      });
+
+      // Now we have a duplicates of each response object, one per evaluator run,
+      // with evaluation results per evaluator. They are not yet merged. We now need
+      // to merge the evaluation results within response objects with the same UIDs.
+      // It *should* be the case (invariant) that response objects with the same UID
+      // have exactly the same number of evaluation results (e.g. n=3 for num resps per prompt=3).
+      const merged_res_objs_by_uid: Dict<LLMResponse> = {};
+      // For each set of evaluation results...
+      evalResults.forEach(({ name, result }) => {
+        // For each response obj in the results...
+        result?.forEach((res_obj: LLMResponse) => {
+          // If it's not already in the merged dict, add it:
+          const uid = res_obj.uid;
+          if (
+            res_obj.eval_res !== undefined &&
+            !(uid in merged_res_objs_by_uid)
+          ) {
+            // Transform evaluation results into dict form, indexed by "name" of the evaluator:
+            res_obj.eval_res.items = res_obj.eval_res.items.map((item) => {
+              if (typeof item === "object") item = item.toString();
+              return {
+                [name]: item,
+              };
+            });
+            res_obj.eval_res.dtype = "KeyValue_Mixed"; // "KeyValue_Mixed" enum;
+            merged_res_objs_by_uid[uid] = res_obj; // we don't make a copy, to save time
+          } else {
+            // It is already in the merged dict, so add the new eval results
+            // Sanity check that the lengths of eval result lists are equal across evaluators:
+            if (merged_res_objs_by_uid[uid].eval_res === undefined) return;
+            else if (
+              // @ts-expect-error We've already checked that eval_res is defined, yet TS throws an error anyway... skip it:
+              merged_res_objs_by_uid[uid].eval_res.items.length !==
+              res_obj.eval_res?.items?.length
+            ) {
+              console.error(
+                `Critical error: Evaluation result lists for response ${uid} do not contain the same number of items per evaluator. Skipping...`,
+              );
+              return;
+            }
+            // Add the new evaluation result, keyed by evaluator name:
+            // @ts-expect-error We've already checked that eval_res is defined, yet TS throws an error anyway... skip it:
+            merged_res_objs_by_uid[uid].eval_res.items.forEach((item, idx) => {
+              if (typeof item === "object") {
+                let v = res_obj.eval_res?.items[idx];
+                if (typeof v === "object") v = v.toString();
+                item[name] = v ?? "undefined";
+              }
+            });
+          }
+        });
+      });
+
+      // We now have a dict of the form { uid: LLMResponse }
+      // We need return only the values of this dict:
+      setLastResponses(Object.values(merged_res_objs_by_uid));
+      setLastRunSuccess(true);
+
+      setStatus(Status.READY);
+    });
+  }, [
+    handlePullInputs,
+    pingOutputNodes,
+    status,
+    showDrawer,
+    evaluators,
+    evaluatorComponents,
+    evaluatorComponentRefs,
+  ]);
+
+  const showResponseInspector = useCallback(() => {
+    if (inspectModal && inspectModal.current && lastResponses) {
+      setUninspectedResponses(false);
+      inspectModal.current.trigger();
+    }
+  }, [inspectModal, lastResponses]);
+
+  // Something changed upstream
+  useEffect(() => {
+    if (data.refresh && data.refresh === true) {
+      setDataPropsForNode(id, { refresh: false });
+      setStatus(Status.WARNING);
+    }
+  }, [data]);
+
+  return (
+    <BaseNode
+      classNames="evaluator-node"
+      nodeId={id}
+      style={{ backgroundColor: "#eee" }}
+    >
+      <NodeLabel
+        title={data.title || "Multi-Evaluator"}
+        nodeId={id}
+        icon={<IconAbacus size="16px" />}
+        status={status}
+        handleRunClick={handleRunClick}
+        runButtonTooltip="Run all evaluators over inputs"
+      />
+
+      <LLMResponseInspectorModal
+        ref={inspectModal}
+        jsonResponses={lastResponses}
+      />
+      {/* <PickCriteriaModal ref={pickCriteriaModalRef} /> */}
+      <iframe style={{ display: "none" }} id={`${id}-iframe`}></iframe>
+
+      {evaluatorComponents}
+
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="responseBatch"
+        className="grouped-handle"
+        style={{ top: "50%" }}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="output"
+        className="grouped-handle"
+        style={{ top: "50%" }}
+      />
+
+      <div className="add-text-field-btn">
+        <Menu withinPortal position="right-start" shadow="sm">
+          <Menu.Target>
+            <Tooltip label="Add evaluator" position="left" withArrow>
+              <ActionIcon variant="outline" color="gray" size="sm">
+                <IconPlus size="12px" />
+              </ActionIcon>
+            </Tooltip>
+          </Menu.Target>
+
+          <Menu.Dropdown>
+            <Menu.Item
+              icon={<IconTerminal size="14px" />}
+              onClick={() =>
+                addEvaluator(
+                  `Criteria ${evaluators.length + 1}`,
+                  "javascript",
+                  {
+                    code: "function evaluate(r) {\n\treturn r.text.length;\n}",
+                  },
+                )
+              }
+            >
+              JavaScript
+            </Menu.Item>
+            {IS_RUNNING_LOCALLY ? (
+              <Menu.Item
+                icon={<IconTerminal size="14px" />}
+                onClick={() =>
+                  addEvaluator(`Criteria ${evaluators.length + 1}`, "python", {
+                    code: "def evaluate(r):\n\treturn len(r.text)",
+                  })
+                }
+              >
+                Python
+              </Menu.Item>
+            ) : (
+              <></>
+            )}
+            <Menu.Item
+              icon={<IconRobot size="14px" />}
+              onClick={() =>
+                addEvaluator(`Criteria ${evaluators.length + 1}`, "llm", {
+                  prompt: "",
+                  format: "bin",
+                })
+              }
+            >
+              LLM
+            </Menu.Item>
+            {AI_SUPPORT_ENABLED ? <Menu.Divider /> : <></>}
+            {/* {AI_SUPPORT_ENABLED ? (
+              <Menu.Item
+                icon={<IconSparkles size="14px" />}
+                onClick={onClickPickCriteria}
+              >
+                Let an AI decide!
+              </Menu.Item>
+            ) : (
+              <></>
+            )} */}
+          </Menu.Dropdown>
+        </Menu>
+      </div>
+
+      {/* EvalGen {evaluators && evaluators.length === 0 ? (
+        <Flex justify="center" gap={12} mt="md">
+          <Tooltip
+            label="Let an AI help you generate criteria and implement evaluation functions."
+            multiline
+            position="bottom"
+            withArrow
+          >
+            <Button onClick={onClickPickCriteria} variant="outline" size="xs">
+              <IconSparkles size="11pt" />
+              &nbsp;Generate criteria
+            </Button>
+          </Tooltip> */}
+      {/* <Button disabled variant='gradient' gradient={{ from: 'teal', to: 'lime', deg: 105 }}><IconSparkles />&nbsp;Validate</Button> */}
+      {/* </Flex>
+      ) : (
+        <></>
+      )} */}
+
+      {lastRunSuccess && lastResponses && lastResponses.length > 0 ? (
+        <InspectFooter
+          label={
+            <>
+              Inspect scores&nbsp;
+              <IconSearch size="12pt" />
+            </>
+          }
+          onClick={showResponseInspector}
+          showNotificationDot={uninspectedResponses}
+          isDrawerOpen={showDrawer}
+          showDrawerButton={true}
+          onDrawerClick={() => {
+            setShowDrawer(!showDrawer);
+            setUninspectedResponses(false);
+            bringNodeToFront(id);
+          }}
+        />
+      ) : (
+        <></>
+      )}
+
+      <LLMResponseInspectorDrawer
+        jsonResponses={lastResponses}
+        showDrawer={showDrawer}
+      />
+    </BaseNode>
+  );
+};
+
+export default MultiEvalNode;

--- a/chainforge/react-server/src/MultiEvalNode.tsx
+++ b/chainforge/react-server/src/MultiEvalNode.tsx
@@ -19,7 +19,6 @@ import {
   Collapse,
   Button,
   Alert,
-  Flex,
   Tooltip,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
@@ -29,7 +28,6 @@ import {
   IconChevronDown,
   IconChevronRight,
   IconDots,
-  IconInfoCircle,
   IconPlus,
   IconRobot,
   IconSearch,
@@ -143,7 +141,6 @@ const EvaluatorContainer: React.FC<EvaluatorContainerProps> = ({
             />
           </Group>
           <Group spacing="4px" ml="auto">
-
             {customButton}
 
             <Text color="#bbb" size="sm" mr="6px">
@@ -294,11 +291,11 @@ const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
         return e;
       }),
     );
-  }
+  };
 
   // const evaluatorComponents = useMemo(() => {
   //   // evaluatorComponentRefs.current = [];
-    
+
   //   return evaluators.map((e, idx) => {
   //     let component: React.ReactNode;
   //     if (e.type === "python" || e.type === "javascript") {
@@ -437,13 +434,15 @@ const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
       progress?: QueryProgress,
     ) => {
       // Update the progress rings, debouncing to avoid too many rerenders
-      debounce((_idx, _progress) => 
-        setEvaluators((evs) => {
-          if (_idx >= evs.length) return evs;
-          evs[_idx].progress = _progress;
-          return [...evs];
-        })
-      , 30)(evaluator_idx, progress);
+      debounce(
+        (_idx, _progress) =>
+          setEvaluators((evs) => {
+            if (_idx >= evs.length) return evs;
+            evs[_idx].progress = _progress;
+            return [...evs];
+          }),
+        30,
+      )(evaluator_idx, progress);
     };
 
     // Run all evaluators here!
@@ -502,13 +501,12 @@ const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
       }
 
       // Remove progress rings without errors
-      setEvaluators((evs) => 
-        evs.map(e => {
-          if (e.progress && !e.progress.error)
-            e.progress = undefined;
+      setEvaluators((evs) =>
+        evs.map((e) => {
+          if (e.progress && !e.progress.error) e.progress = undefined;
           return e;
-        })
-      )
+        }),
+      );
 
       // Ignore null refs
       settled = settled.filter(
@@ -638,94 +636,104 @@ const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
       <iframe style={{ display: "none" }} id={`${id}-iframe`}></iframe>
 
       {/* {evaluatorComponents} */}
-      {evaluators.map((e, idx) => 
-          <EvaluatorContainer
-            name={e.name}
-            key={`${e.name}-${idx}`}
-            type={EVAL_TYPE_PRETTY_NAME[e.type]}
-            progress={e.progress}
-            customButton={e.state?.sandbox !== undefined ? (
-              <Tooltip label={
-                e.state?.sandbox
-                  ? "Running in sandbox (pyodide)"
-                  : "Running unsandboxed (local Python)"
-              } withinPortal withArrow>
-
-              <button
-                onClick={() => updateEvalState(idx, (e) => (e.state.sandbox = !e.state.sandbox))}
-                className="custom-button"
-                style={{ border: "none", padding: "0px", marginTop: "3px" }}
+      {evaluators.map((e, idx) => (
+        <EvaluatorContainer
+          name={e.name}
+          key={`${e.name}-${idx}`}
+          type={EVAL_TYPE_PRETTY_NAME[e.type]}
+          progress={e.progress}
+          customButton={
+            e.state?.sandbox !== undefined ? (
+              <Tooltip
+                label={
+                  e.state?.sandbox
+                    ? "Running in sandbox (pyodide)"
+                    : "Running unsandboxed (local Python)"
+                }
+                withinPortal
+                withArrow
               >
-                <IconBox
-                  size="12pt"
-                  color={e.state.sandbox ? "orange" : "#999"}
-                />
-                
-              </button>
+                <button
+                  onClick={() =>
+                    updateEvalState(
+                      idx,
+                      (e) => (e.state.sandbox = !e.state.sandbox),
+                    )
+                  }
+                  className="custom-button"
+                  style={{ border: "none", padding: "0px", marginTop: "3px" }}
+                >
+                  <IconBox
+                    size="12pt"
+                    color={e.state.sandbox ? "orange" : "#999"}
+                  />
+                </button>
               </Tooltip>
-            ) : undefined}
-            onDelete={() => {
-              delete evaluatorComponentRefs.current[idx];
-              setEvaluators(evaluators.filter((_, i) => i !== idx));
-            }}
-            onChangeTitle={(newTitle) =>
-              setEvaluators((evs) => 
-                evs.map((e, i) => {
-                  if (i === idx) e.name = newTitle;
-                  console.log(e);
-                  return e;
-                }),
-              )
-            }
-            padding={e.type === "llm" ? "8px" : undefined}
-          >
-            {
-              (e.type === "python" || e.type === "javascript") ? <CodeEvaluatorComponent
-                    ref={(el) =>
-                      (evaluatorComponentRefs.current[idx] = {
-                        type: "code",
-                        name: e.name,
-                        ref: el,
-                      })
-                    }
-                    code={e.state?.code}
-                    progLang={e.type}
-                    sandbox={e.state?.sandbox}
-                    type="evaluator"
-                    id={id}
-                    onCodeEdit={(code) =>
-                      updateEvalState(idx, (e) => (e.state.code = code))
-                    }
-                    showUserInstruction={false}
-                  />
-              : (e.type === "llm") ?
-                  <LLMEvaluatorComponent
-                    ref={(el) =>
-                      (evaluatorComponentRefs.current[idx] = {
-                        type: "llm",
-                        name: e.name,
-                        ref: el,
-                      })
-                    }
-                    prompt={e.state?.prompt}
-                    grader={e.state?.grader}
-                    format={e.state?.format}
-                    id={`${id}-${e.uid}`}
-                    showUserInstruction={false}
-                    onPromptEdit={(prompt) =>
-                      updateEvalState(idx, (e) => (e.state.prompt = prompt))
-                    }
-                    onLLMGraderChange={(grader) =>
-                      updateEvalState(idx, (e) => (e.state.grader = grader))
-                    }
-                    onFormatChange={(format) =>
-                      updateEvalState(idx, (e) => (e.state.format = format))
-                    }
-                  />
-              : <Alert>Error: Unknown evaluator type {e.type}</Alert>
-            }
+            ) : undefined
+          }
+          onDelete={() => {
+            delete evaluatorComponentRefs.current[idx];
+            setEvaluators(evaluators.filter((_, i) => i !== idx));
+          }}
+          onChangeTitle={(newTitle) =>
+            setEvaluators((evs) =>
+              evs.map((e, i) => {
+                if (i === idx) e.name = newTitle;
+                console.log(e);
+                return e;
+              }),
+            )
+          }
+          padding={e.type === "llm" ? "8px" : undefined}
+        >
+          {e.type === "python" || e.type === "javascript" ? (
+            <CodeEvaluatorComponent
+              ref={(el) =>
+                (evaluatorComponentRefs.current[idx] = {
+                  type: "code",
+                  name: e.name,
+                  ref: el,
+                })
+              }
+              code={e.state?.code}
+              progLang={e.type}
+              sandbox={e.state?.sandbox}
+              type="evaluator"
+              id={id}
+              onCodeEdit={(code) =>
+                updateEvalState(idx, (e) => (e.state.code = code))
+              }
+              showUserInstruction={false}
+            />
+          ) : e.type === "llm" ? (
+            <LLMEvaluatorComponent
+              ref={(el) =>
+                (evaluatorComponentRefs.current[idx] = {
+                  type: "llm",
+                  name: e.name,
+                  ref: el,
+                })
+              }
+              prompt={e.state?.prompt}
+              grader={e.state?.grader}
+              format={e.state?.format}
+              id={`${id}-${e.uid}`}
+              showUserInstruction={false}
+              onPromptEdit={(prompt) =>
+                updateEvalState(idx, (e) => (e.state.prompt = prompt))
+              }
+              onLLMGraderChange={(grader) =>
+                updateEvalState(idx, (e) => (e.state.grader = grader))
+              }
+              onFormatChange={(format) =>
+                updateEvalState(idx, (e) => (e.state.format = format))
+              }
+            />
+          ) : (
+            <Alert>Error: Unknown evaluator type {e.type}</Alert>
+          )}
         </EvaluatorContainer>
-      )}
+      ))}
 
       <Handle
         type="target"

--- a/chainforge/react-server/src/MultiEvalNode.tsx
+++ b/chainforge/react-server/src/MultiEvalNode.tsx
@@ -98,8 +98,8 @@ const EvaluatorContainer: React.FC<EvaluatorContainerProps> = ({
   return (
     <Card
       withBorder
-      shadow="sm"
-      mb="xs"
+      // shadow="sm"
+      mb={4}
       radius="md"
       style={{ cursor: "default" }}
     >
@@ -132,7 +132,7 @@ const EvaluatorContainer: React.FC<EvaluatorContainerProps> = ({
                   padding: "0px",
                   height: "14pt",
                   minHeight: "0pt",
-                  fontWeight: "bold",
+                  fontWeight: 500,
                 },
               }}
             />

--- a/chainforge/react-server/src/ResponseBoxes.tsx
+++ b/chainforge/react-server/src/ResponseBoxes.tsx
@@ -164,10 +164,12 @@ export const genResponseTextsDisplay = (
   onlyShowScores?: boolean,
   llmName?: string,
   wideFormat?: boolean,
+  hideEvalScores?: boolean,
 ): React.ReactNode[] | React.ReactNode => {
   if (!res_obj) return <></>;
 
-  const eval_res_items = res_obj.eval_res ? res_obj.eval_res.items : null;
+  const eval_res_items =
+    !hideEvalScores && res_obj.eval_res ? res_obj.eval_res.items : null;
 
   // Bucket responses that have the same text, and sort by the
   // number of same responses so that the top div is the most prevalent response.

--- a/chainforge/react-server/src/ResponseBoxes.tsx
+++ b/chainforge/react-server/src/ResponseBoxes.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useMemo, lazy } from "react";
-import { Collapse, Flex } from "@mantine/core";
+import { Collapse, Flex, Stack } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { truncStr } from "./backend/utils";
 import {
@@ -15,19 +15,25 @@ const ResponseRatingToolbar = lazy(() => import("./ResponseRatingToolbar"));
 /* HELPER FUNCTIONS */
 const SUCCESS_EVAL_SCORES = new Set(["true", "yes"]);
 const FAILURE_EVAL_SCORES = new Set(["false", "no"]);
-const getEvalResultStr = (
-  eval_item: string[] | Dict | string | number | boolean,
+export const getEvalResultStr = (
+  eval_item: EvaluationScore,
+  hide_prefix: boolean,
 ) => {
   if (Array.isArray(eval_item)) {
-    return "scores: " + eval_item.join(", ");
+    return (hide_prefix ? "" : "scores: ") + eval_item.join(", ");
   } else if (typeof eval_item === "object") {
-    const strs = Object.keys(eval_item).map((key) => {
+    const strs = Object.keys(eval_item).map((key, j) => {
       let val = eval_item[key];
       if (typeof val === "number" && val.toString().indexOf(".") > -1)
         val = val.toFixed(4); // truncate floats to 4 decimal places
-      return `${key}: ${val}`;
+      return (
+        <div key={`${key}-${j}`}>
+          <span>{key}: </span>
+          <span>{getEvalResultStr(val, true)}</span>
+        </div>
+      );
     });
-    return strs.join(", ");
+    return <Stack spacing={0}>{strs}</Stack>;
   } else {
     const eval_str = eval_item.toString().trim().toLowerCase();
     const color = SUCCESS_EVAL_SCORES.has(eval_str)
@@ -37,7 +43,7 @@ const getEvalResultStr = (
         : "black";
     return (
       <>
-        <span style={{ color: "gray" }}>{"score: "}</span>
+        {!hide_prefix && <span style={{ color: "gray" }}>{"score: "}</span>}
         <span style={{ color }}>{eval_str}</span>
       </>
     );
@@ -253,7 +259,7 @@ export const genResponseTextsDisplay = (
         )}
         {eval_res_items ? (
           <p className="small-response-metrics">
-            {getEvalResultStr(resp_str_to_eval_res[r])}
+            {getEvalResultStr(resp_str_to_eval_res[r], true)}
           </p>
         ) : (
           <></>

--- a/chainforge/react-server/src/backend/backend.ts
+++ b/chainforge/react-server/src/backend/backend.ts
@@ -1254,7 +1254,6 @@ export async function evalWithLLM(
       .flat();
 
     // Now run all inputs through the LLM grader!:
-    console.log(llm);
     const { responses, errors } = await queryLLM(
       `eval-${id}-${cache_id}`,
       [llm],

--- a/chainforge/react-server/src/backend/backend.ts
+++ b/chainforge/react-server/src/backend/backend.ts
@@ -1254,6 +1254,7 @@ export async function evalWithLLM(
       .flat();
 
     // Now run all inputs through the LLM grader!:
+    console.log(llm);
     const { responses, errors } = await queryLLM(
       `eval-${id}-${cache_id}`,
       [llm],

--- a/chainforge/react-server/src/backend/typing.ts
+++ b/chainforge/react-server/src/backend/typing.ts
@@ -199,6 +199,7 @@ export type EvaluationScore =
   | number
   | string
   | Dict<boolean | number | string>;
+
 export type EvaluationResults = {
   items: EvaluationScore[];
   dtype:

--- a/chainforge/react-server/src/text-fields-node.css
+++ b/chainforge/react-server/src/text-fields-node.css
@@ -4,6 +4,9 @@
 .monofont {
   font-family: var(--monofont);
 }
+.linebreaks {
+  white-space: pre-wrap;
+}
 
 .text-fields-node {
   background-color: #fff;
@@ -390,7 +393,7 @@ g.ytick text {
   padding-bottom: 20px;
   min-width: 160px;
   border-right: 1px solid #eee;
-  padding-left: 8px !important;
+  padding-left: 0px !important;
   padding-right: 0px !important;
 }
 .inspect-responses-drawer {
@@ -646,17 +649,18 @@ g.ytick text {
   cursor: text;
 }
 .small-response-metrics {
-  font-size: 10pt;
+  font-size: 9pt;
   font-family: -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: 500;
   text-align: center;
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
-  padding: 0px 2px 1px 0px;
+  padding: 0px 2px 2px 0px;
   margin: 8px 20% -6px 20%;
-  background-color: rgba(255, 255, 255, 0.3);
+  /* background-color: rgba(255, 255, 255, 0.3); */
   color: #333;
+  white-space: pre-wrap;
 }
 .num-same-responses {
   position: relative;

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='chainforge',
-    version='0.3.1.2',
+    version='0.3.1.5',
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION
First commit to adding the MultiEval node to ChainForge proper, alongside:
- improvements to response inspector table view to display multi-criteria scoring in column view
- table view is now default when multiple evaluators are detected

Voilà:

<img width="1321" alt="Screen Shot 2024-03-17 at 12 21 37 AM" src="https://github.com/ianarawjo/ChainForge/assets/5251713/28dcd7e5-8214-4afc-8691-e7182f8ae2f0">


### This is a "beta" version of the `MultiEval` node, for two reasons:
- The output handle of MultiEval is disabled, since it doesn't yet work with VisNodes to plot data across multiple criteria. That is a separate issue that I didn't want holding up this push. It is coming.
- There are no genAI features in MultiEval, yet, like there are in Code Evaluator nodes. I want to do this right (beyond EvalGen, which is another matter). The idea is that you can describe the criteria in a prompt and the AI will add an evaluator to the list that it thinks is the best, on a per-criteria basis. For now as a workaround, you can use the genAI feature to generate code inside single Code Evaluators and port that code over.

The [`EvalGen` wizard](https://arxiv.org/abs/2404.12272) is also coming, to help users automatically generate evaluation metrics with human supervision. We have a version of this on the `multi-eval` branch (which due to the TypeScript front-end rewrite, we cannot directly merge into `main`), but it doesn't integrate Shreya's fixes. 