### PR TITLE
Support for Llama3 via Amazon Bedrock

### DIFF
--- a/chainforge/react-server/package-lock.json
+++ b/chainforge/react-server/package-lock.json
@@ -22,7 +22,7 @@
         "@mantine/dropzone": "^6.0.19",
         "@mantine/form": "^6.0.11",
         "@mantine/prism": "^6.0.15",
-        "@mirai73/bedrock-fm": "^0.4.8",
+        "@mirai73/bedrock-fm": "^0.4.9",
         "@reactflow/background": "^11.2.0",
         "@reactflow/controls": "^11.1.11",
         "@reactflow/core": "^11.7.0",
@@ -4653,9 +4653,9 @@
       }
     },
     "node_modules/@mirai73/bedrock-fm": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@mirai73/bedrock-fm/-/bedrock-fm-0.4.8.tgz",
-      "integrity": "sha512-21dMQOMqg3BER+NDl3gXICIo9ur+m4yvtuVjQArNSqOWsDEyeQOKjzSYqV3xPMSStp7Q1Z8HCzH069hsKdBXsw==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@mirai73/bedrock-fm/-/bedrock-fm-0.4.9.tgz",
+      "integrity": "sha512-wKcIUEZPKAOEjESeb5viOtQos9VzzU2UuhcSIlGxJF1/VlIJz5y2hCzo5rEPVAuMYGWx5a0G3+CBTx3z/tlEgg==",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.507.0"
       }

--- a/chainforge/react-server/package.json
+++ b/chainforge/react-server/package.json
@@ -20,7 +20,7 @@
     "@mantine/dropzone": "^6.0.19",
     "@mantine/form": "^6.0.11",
     "@mantine/prism": "^6.0.15",
-    "@mirai73/bedrock-fm": "^0.4.8",
+    "@mirai73/bedrock-fm": "^0.4.9",
     "@reactflow/background": "^11.2.0",
     "@reactflow/controls": "^11.1.11",
     "@reactflow/core": "^11.7.0",

--- a/chainforge/react-server/src/LLMEvalNode.tsx
+++ b/chainforge/react-server/src/LLMEvalNode.tsx
@@ -126,8 +126,7 @@ export const LLMEvaluatorComponent = forwardRef<
       setPromptText(e.target.value);
 
       // Update the caller, but debounce to reduce the number of callbacks when user is typing
-      if (onPromptEdit) 
-        debounce(() => onPromptEdit(e.target.value), 200)();
+      if (onPromptEdit) debounce(() => onPromptEdit(e.target.value), 200)();
     },
     [setPromptText, onPromptEdit],
   );

--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -13,6 +13,7 @@
 import {
   LLMProvider,
   MAX_CONCURRENT,
+  NativeLLM,
   RATE_LIMIT_BY_MODEL,
   getProvider,
 } from "./backend/models";
@@ -1353,13 +1354,14 @@ const BedrockClaudeSettings: ModelSettingsDict = {
         description:
           "Select a version of Claude to query. For more details on the differences, see the Anthropic API documentation.",
         enum: [
-          "anthropic.claude-3-sonnet-20240229-v1:0",
-          "anthropic.claude-3-haiku-20240307-v1:0",
-          "anthropic.claude-v2:1",
-          "anthropic.claude-v2",
-          "anthropic.claude-instant-v1",
+          NativeLLM.Bedrock_Claude_3_Opus,
+          NativeLLM.Bedrock_Claude_3_Haiku,
+          NativeLLM.Bedrock_Claude_3_Sonnet,
+          NativeLLM.Bedrock_Claude_Instant_1,
+          NativeLLM.Bedrock_Claude_2,
+          NativeLLM.Bedrock_Claude_2_1,
         ],
-        default: "anthropic.claude-3-haiku-20240307-v1:0",
+        default: NativeLLM.Bedrock_Claude_3_Haiku,
         shortname_map: {
           "anthropic.claude-3-sonnet-20240229-v1:0": "claude-3-sonnet",
           "anthropic.claude-3-haiku-20240307-v1:0": "claude-3-haiku",
@@ -1488,8 +1490,11 @@ const BedrockJurassic2Settings: ModelSettingsDict = {
         title: "Model Version",
         description:
           "Select a version of Jurassic 2 to query. For more details on the differences, see the AI21 API documentation.",
-        enum: ["ai21.j2-ultra", "ai21.j2-mid"],
-        default: "ai21.j2-ultra",
+        enum: [
+          NativeLLM.Bedrock_Jurassic_Mid,
+          NativeLLM.Bedrock_Jurassic_Ultra,
+        ],
+        default: NativeLLM.Bedrock_Jurassic_Ultra,
       },
       temperature: {
         type: "number",
@@ -1609,11 +1614,11 @@ const BedrockTitanSettings: ModelSettingsDict = {
         description:
           "Select a version of Amazon Titan to query. For more details on the differences, see the Amazon Titan API documentation.",
         enum: [
-          "amazon.titan-tg1-large",
-          "amazon.titan-text-lite-v1",
-          "amazon.titan-text-express-v1",
+          NativeLLM.Bedrock_Titan_Large,
+          NativeLLM.Bedrock_Titan_Light,
+          NativeLLM.Bedrock_Titan_Express,
         ],
-        default: "amazon.titan-tg1-large",
+        default: NativeLLM.Bedrock_Titan_Large,
       },
       temperature: {
         type: "number",
@@ -1703,8 +1708,11 @@ const BedrockCommandTextSettings: ModelSettingsDict = {
         title: "Model Version",
         description:
           "Select a version of Command Cohere to query. For more details on the differences, see the Cohere API documentation.",
-        enum: ["cohere.command-text-v14", "cohere.command-light-text-v14"],
-        default: "cohere.command-text-v14",
+        enum: [
+          NativeLLM.Bedrock_Command_Text,
+          NativeLLM.Bedrock_Command_Text_Light,
+        ],
+        default: NativeLLM.Bedrock_Command_Text,
       },
       temperature: {
         type: "number",
@@ -1817,10 +1825,10 @@ const MistralSettings: ModelSettingsDict = {
         description:
           "Select a version of Mistral model to query. For more details on the differences, see the Mistral API documentation.",
         enum: [
-          "mistral.mistral-7b-instruct-v0:2",
-          "mistral.mistral-large-2402-v1:0",
+          NativeLLM.Bedrock_Mistral_Mistral,
+          NativeLLM.Bedrock_Mistral_Mistral_Large,
         ],
-        default: "mistral.mistral-7b-instruct-v0:2",
+        default: NativeLLM.Bedrock_Mistral_Mistral,
       },
       temperature: {
         type: "number",
@@ -1917,8 +1925,8 @@ MixtralSettings.schema.properties = {
       title: "Model Version",
       description:
         "Select a version of Mistral model to query. For more details on the differences, see the Mixtral API documentation.",
-      enum: ["mistral.mixtral-8x7b-instruct-v0:1"],
-      default: "mistral.mixtral-8x7b-instruct-v0:1",
+      enum: [NativeLLM.Bedrock_Mistral_Mixtral],
+      default: NativeLLM.Bedrock_Mistral_Mixtral,
     },
     shortname: {
       type: "string",
@@ -1931,7 +1939,7 @@ MixtralSettings.schema.properties = {
 
 MixtralSettings.uiSchema.model = { "ui:help": "Defaults to Mixtral" };
 
-const MetaLlama2ChatSettings: ModelSettingsDict = {
+const BedrockLlama2ChatSettings: ModelSettingsDict = {
   fullName: "Llama2Chat (Meta) via Amazon Bedrock",
   schema: {
     type: "object",
@@ -1948,9 +1956,12 @@ const MetaLlama2ChatSettings: ModelSettingsDict = {
         type: "string",
         title: "Model Version",
         description:
-          "Select a version of Command Cohere to query. For more details on the differences, see the Cohere API documentation.",
-        enum: ["meta.llama2-13b-chat-v1", "meta.llama2-70b-chat-v1"],
-        default: "meta.llama2-13b-chat-v1",
+          "Select a version of Meta Llama2 model to query. For more details on the differences, see the Meta Llama API documentation.",
+        enum: [
+          NativeLLM.Bedrock_Meta_LLama2Chat_13b,
+          NativeLLM.Bedrock_Meta_LLama2Chat_70b,
+        ],
+        default: NativeLLM.Bedrock_Meta_LLama2Chat_13b,
       },
       temperature: {
         type: "number",
@@ -2022,6 +2033,35 @@ const MetaLlama2ChatSettings: ModelSettingsDict = {
   },
 };
 
+const BedrockLlama3Settings = deepcopy(BedrockLlama2ChatSettings);
+
+BedrockLlama3Settings.schema.properties = {
+  ...deepcopy(BedrockLlama3Settings.schema.properties),
+  ...{
+    model: {
+      type: "string",
+      title: "Model Version",
+      description:
+        "Select a version of Meta Llama3 model to query. For more details on the differences, see the Meta Llama3 API documentation.",
+      enum: [
+        NativeLLM.Bedrock_Meta_LLama3Instruct_8b,
+        NativeLLM.Bedrock_Meta_LLama3Instruct_70b,
+      ],
+      default: NativeLLM.Bedrock_Meta_LLama3Instruct_8b,
+    },
+    shortname: {
+      type: "string",
+      title: "Nickname",
+      description: "Unique identifier to appear in ChainForge. Keep it short.",
+      default: "Llama3Instruct8b",
+    },
+  },
+};
+
+BedrockLlama3Settings.uiSchema.model = {
+  "ui:help": "Defaults to Llama3Instruct8b",
+};
+
 // A lookup table indexed by base_model.
 export const ModelSettings: Dict<ModelSettingsDict> = {
   "gpt-3.5-turbo": ChatGPTSettings,
@@ -2040,7 +2080,8 @@ export const ModelSettings: Dict<ModelSettingsDict> = {
   "br.cohere.command": BedrockCommandTextSettings,
   "br.mistral.mistral": MistralSettings,
   "br.mistral.mixtral": MixtralSettings,
-  "br.meta.llama2": MetaLlama2ChatSettings,
+  "br.meta.llama2": BedrockLlama2ChatSettings,
+  "br.meta.llama3": BedrockLlama3Settings,
 };
 
 export function getSettingsSchemaForLLM(

--- a/chainforge/react-server/src/backend/models.ts
+++ b/chainforge/react-server/src/backend/models.ts
@@ -93,6 +93,7 @@ export enum NativeLLM {
   Bedrock_Claude_2 = "anthropic.claude-v2",
   Bedrock_Claude_3_Sonnet = "anthropic.claude-3-sonnet-20240229-v1:0",
   Bedrock_Claude_3_Haiku = "anthropic.claude-3-haiku-20240307-v1:0",
+  Bedrock_Claude_3_Opus = "anthropic.claude-3-opus-20240229-v1:0",
   Bedrock_Claude_Instant_1 = "anthropic.claude-instant-v1",
   Bedrock_Jurassic_Ultra = "ai21.j2-ultra",
   Bedrock_Jurassic_Mid = "ai21.j2-mid",
@@ -103,6 +104,8 @@ export enum NativeLLM {
   Bedrock_Command_Text_Light = "cohere.command-light-text-v14",
   Bedrock_Meta_LLama2Chat_13b = "meta.llama2-13b-chat-v1",
   Bedrock_Meta_LLama2Chat_70b = "meta.llama2-70b-chat-v1",
+  Bedrock_Meta_LLama3Instruct_8b = "meta.llama3-8b-instruct-v1:0",
+  Bedrock_Meta_LLama3Instruct_70b = "meta.llama3-70b-instruct-v1:0",
   Bedrock_Mistral_Mistral = "mistral.mistral-7b-instruct-v0:2",
   Bedrock_Mistral_Mistral_Large = "mistral.mistral-large-2402-v1:0",
   Bedrock_Mistral_Mixtral = "mistral.mixtral-8x7b-instruct-v0:1",
@@ -187,16 +190,20 @@ export const RATE_LIMIT_BY_MODEL: { [key in LLM]?: number } = {
   [NativeLLM.Bedrock_Jurassic_Ultra]: 25,
   [NativeLLM.Bedrock_Titan_Light]: 800,
   [NativeLLM.Bedrock_Titan_Express]: 400, // 400 RPM
-  [NativeLLM.Bedrock_Claude_2]: 100, // 100 RPM
-  [NativeLLM.Bedrock_Claude_2_1]: 100, // 100 RPM
-  [NativeLLM.Bedrock_Claude_3_Haiku]: 100, // 100 RPM
+  [NativeLLM.Bedrock_Claude_2]: 500, // 500 RPM
+  [NativeLLM.Bedrock_Claude_2_1]: 500, // 500 RPM
+  [NativeLLM.Bedrock_Claude_3_Haiku]: 1000, // 1000 RPM
   [NativeLLM.Bedrock_Claude_3_Sonnet]: 100, // 100 RPM
+  [NativeLLM.Bedrock_Claude_3_Opus]: 50, // 50 RPM
+  [NativeLLM.Bedrock_Claude_Instant_1]: 1000, // 1000 RPM
   [NativeLLM.Bedrock_Command_Text]: 400, // 400 RPM
   [NativeLLM.Bedrock_Command_Text_Light]: 800, // 800 RPM
   [NativeLLM.Bedrock_Meta_LLama2Chat_70b]: 400, // 400 RPM
   [NativeLLM.Bedrock_Meta_LLama2Chat_13b]: 800, // 800 RPM
+  [NativeLLM.Bedrock_Meta_LLama3Instruct_8b]: 400, // 400 RPM
+  [NativeLLM.Bedrock_Meta_LLama3Instruct_70b]: 800, // 800 RPM
   [NativeLLM.Bedrock_Mistral_Mixtral]: 400, // 400 RPM
-  [NativeLLM.Bedrock_Mistral_Mistral_Large]: 100, // 100 RPM
+  [NativeLLM.Bedrock_Mistral_Mistral_Large]: 400, // 400 RPM
   [NativeLLM.Bedrock_Mistral_Mistral]: 800, // 800 RPM
 };
 

--- a/chainforge/react-server/src/store.tsx
+++ b/chainforge/react-server/src/store.tsx
@@ -26,6 +26,7 @@ import {
   TabularDataColType,
   TabularDataRowType,
 } from "./backend/typing";
+import { NativeLLM } from "./backend/models";
 
 // Initial project settings
 const initialAPIKeys = {};
@@ -173,50 +174,57 @@ export const initLLMProviderMenu: (
       {
         name: "Anthropic Claude",
         emoji: "👨‍🏫",
-        model: "anthropic.claude-v2:1",
+        model: NativeLLM.Bedrock_Claude_3_Haiku,
         base_model: "br.anthropic.claude",
         temp: 0.9,
       },
       {
         name: "AI21 Jurassic 2",
         emoji: "🦖",
-        model: "ai21.j2-ultra",
+        model: NativeLLM.Bedrock_Jurassic_Ultra,
         base_model: "br.ai21.j2",
         temp: 0.9,
       },
       {
         name: "Amazon Titan",
         emoji: "🏛️",
-        model: "amazon.titan-tg1-large",
+        model: NativeLLM.Bedrock_Titan_Large,
         base_model: "br.amazon.titan",
         temp: 0.9,
       },
       {
         name: "Cohere Command Text 14",
         emoji: "📚",
-        model: "cohere.command-text-v14",
+        model: NativeLLM.Bedrock_Command_Text,
         base_model: "br.cohere.command",
         temp: 0.9,
       },
       {
         name: "Mistral Mistral",
         emoji: "💨",
-        model: "mistral.mistral-7b-instruct-v0:2",
+        model: NativeLLM.Bedrock_Mistral_Mistral,
         base_model: "br.mistral.mistral",
         temp: 0.9,
       },
       {
         name: "Mistral Mixtral",
         emoji: "🌪️",
-        model: "mistral.mixtral-8x7b-instruct-v0:1",
+        model: NativeLLM.Bedrock_Mistral_Mixtral,
         base_model: "br.mistral.mixtral",
         temp: 0.9,
       },
       {
         name: "Meta Llama2 Chat",
         emoji: "🦙",
-        model: "meta.llama2-13b-chat-v1",
+        model: NativeLLM.Bedrock_Meta_LLama2Chat_13b,
         base_model: "br.meta.llama2",
+        temp: 0.9,
+      },
+      {
+        name: "Meta Llama3 Instruct",
+        emoji: "🦙",
+        model: NativeLLM.Bedrock_Meta_LLama3Instruct_8b,
+        base_model: "br.meta.llama3",
         temp: 0.9,
       },
     ],


### PR DESCRIPTION
This PR adds support for Llama3 models via Amazon Bedrock. It also add Anthropic Claude 3 Opus to the list of models.

To avoid referring to hardocded model Id strings in several piece of code, we replaced all hardcoded model Id strings used by Bedrock models with the corresponding `NativeLLM` enum value.