### PR TITLE
Hook up backend executor with evalgen2

### DIFF
--- a/chainforge/react-server/src/ResponseRatingToolbar.tsx
+++ b/chainforge/react-server/src/ResponseRatingToolbar.tsx
@@ -23,6 +23,10 @@ const collapse_ratings = (rating_dict: RatingDict, idxs: number[]) => {
   return undefined;
 };
 
+export const extractUIDFromRatingKey = (key) => {
+  return key.substring(2, key.lastIndexOf("."));
+};
+
 export const getLabelForResponse = (uid: string, label_name: string) => {
   return StorageCache.get(getRatingKeyForResponse(uid, label_name));
 };

--- a/chainforge/react-server/src/backend/evalgen/executor.ts
+++ b/chainforge/react-server/src/backend/evalgen/executor.ts
@@ -9,8 +9,9 @@ import {
   EvalFunctionResult,
   EvalFunctionReport,
   EvalFunctionSetReport,
+  EvalCriteriaUID
 } from "./typing";
-import { LLMResponse, ResponseUID, QueryProgress } from "../typing";
+import { LLMResponse, ResponseUID, QueryProgress, Dict } from "../typing";
 import { EventEmitter } from "events";
 
 /**
@@ -66,12 +67,16 @@ export default class EvaluationFunctionExecutor {
   // Cache function results for each example
   private resultsCache: Map<EvalFunction, Map<ResponseUID, EvalFunctionResult>>;
   private grades: Map<ResponseUID, boolean>; // Grades for all examples
+  private perCriteriaGrades: Dict<Dict<boolean | undefined>>; // Grades per criteria
+  private annotations: Dict<string>; // Annotations for each response
   private lastPickedHighScore: boolean; // To alternate between highest and lowest scores when sampling examples to grade
   private examples: LLMResponse[]; // The set of examples being evaluated and graded
   private evalCriteria: EvalCriteria[]; // The criteria used to generate evaluation functions
   private evalFunctions: EvalFunction[]; // The set of evaluation functions generated for the developer's LLM chain
   private promptTemplate: string; // The prompt template for the developer's LLM chain
   private backgroundTaskPromise: Promise<void> | null = null; // To keep track of the background task for generating and executing evaluation functions
+  private criteriaQueue: EvalCriteria[] = []; // Queue for new criteria to be processed
+  private processing = false; // To keep track of whether we are currently processing a criteria
 
   /**
    * Initializes a new instance of the EvaluationFunctionExecutor class.
@@ -86,7 +91,12 @@ export default class EvaluationFunctionExecutor {
     examples: LLMResponse[],
     evalCriteria: EvalCriteria[] = [],
     existingGrades?: Record<ResponseUID, boolean>,
+    existingPerCriteriaGrades?: Dict<Dict<boolean | undefined>>,
+    annotations?: Dict<string>
   ) {
+
+    console.log(evalCriteria);
+
     this.resultsCache = new Map<
       EvalFunction,
       Map<ResponseUID, EvalFunctionResult>
@@ -105,7 +115,9 @@ export default class EvaluationFunctionExecutor {
     }
 
     this.grades = new Map<ResponseUID, boolean>();
+    this.perCriteriaGrades = {};
     this.evalFunctions = [];
+    this.annotations = {};
 
     // Pass in any existing grades
     if (existingGrades) {
@@ -113,7 +125,21 @@ export default class EvaluationFunctionExecutor {
         this.grades.set(uid, grade);
       });
     }
+
+    // Pass in any existing per-criteria grades
+    if (existingPerCriteriaGrades) {
+      this.perCriteriaGrades = existingPerCriteriaGrades;
+    }
+
+    if (annotations) {
+      this.annotations = annotations;
+    }
+
+    this.criteriaQueue = [];
+    this.processing = false;
   }
+
+
 
   /**
    * Starts the background computation for generating and executing evaluation functions.
@@ -157,6 +183,68 @@ export default class EvaluationFunctionExecutor {
     return this.backgroundTaskPromise !== null;
   }
 
+  private async generateAndExecuteFunctionsForCriteria(
+    criteria: EvalCriteria,
+    onProgress?: (progress: QueryProgress) => void,
+  ): Promise<void> {
+    const emitter = new EventEmitter();
+    const functionExecutionPromises: Promise<any>[] = [];
+
+    emitter.on("functionGenerated", (evalFunction) => {
+      const executionPromise = (async () => {
+        this.evalFunctions.push(evalFunction);
+        const executionPromises = this.examples.map(async (example) => {
+
+          // Get random positive and negative examples for this criteria using the perCriteriaGrades
+          const criteriaId = criteria.uid;
+          const randomPositiveExample = this.examples.find(example => this.perCriteriaGrades[criteriaId]?.[example.uid] === true);
+          const randomNegativeExample = this.examples.find(example => this.perCriteriaGrades[criteriaId]?.[example.uid] === false);
+ 
+
+          const funcToExecute =
+            evalFunction.evalCriteria.eval_method === "code"
+              ? execPyFunc
+              : executeLLMEval;
+
+          const result = await funcToExecute(evalFunction, example, randomPositiveExample, randomNegativeExample);
+
+          if (onProgress) {
+            onProgress({
+              success: (100 * functionExecutionPromises.length) / this.criteriaQueue.length,
+              error: 0,
+            });
+          }
+
+          if (!this.resultsCache.has(evalFunction)) {
+            this.resultsCache.set(evalFunction, new Map());
+          }
+          this.resultsCache.get(evalFunction)?.set(example.uid, result);
+
+          if (result === EvalFunctionResult.FAIL) {
+            this.updateScore(example.uid, evalFunction);
+          }
+        });
+
+        await Promise.all(executionPromises);
+      })();
+
+      functionExecutionPromises.push(executionPromise);
+    });
+
+  
+    await generateFunctionsForCriteria(
+      criteria,
+      this.promptTemplate,
+      this.examples[Math.floor(Math.random() * this.examples.length)],
+      emitter,
+    );
+
+    console.log(`Generated functions for criteria: ${criteria.shortname}`);
+    console.log(`Number of functions generated: ${functionExecutionPromises.length}`);
+
+    await Promise.all(functionExecutionPromises);
+  }
+
   /**
    * Generates and executes evaluation functions for a set of examples based on provided criteria.
    * This method is responsible for initializing the evaluation process and managing the asynchronous execution of functions.
@@ -192,13 +280,18 @@ export default class EvaluationFunctionExecutor {
         this.evalFunctions.push(evalFunction);
 
         const executionPromises = this.examples.map(async (example) => {
+          // Get random positive and negative examples for this criteria using the perCriteriaGrades
+          const criteriaId =  evalFunction.evalCriteria.uid;
+          const randomPositiveExample = this.examples.find(example => this.perCriteriaGrades[criteriaId]?.[example.uid] === true);
+          const randomNegativeExample = this.examples.find(example => this.perCriteriaGrades[criteriaId]?.[example.uid] === false);
+
           const funcToExecute =
             evalFunction.evalCriteria.eval_method === "code"
               ? execPyFunc
               : executeLLMEval;
 
           // Run the function on the example and if there's an error, increment skipped
-          const result = await funcToExecute(evalFunction, example);
+          const result = await funcToExecute(evalFunction, example, randomPositiveExample, randomNegativeExample);
 
           funcsExecuted++;
           if (onProgress) {
@@ -219,11 +312,6 @@ export default class EvaluationFunctionExecutor {
             this.updateScore(example.uid, evalFunction);
           }
 
-          // Put result in cache
-          if (!this.resultsCache.has(evalFunction)) {
-            this.resultsCache.set(evalFunction, new Map());
-          }
-          this.resultsCache.get(evalFunction)?.set(example.uid, result);
         });
 
         await Promise.all(executionPromises);
@@ -270,6 +358,63 @@ export default class EvaluationFunctionExecutor {
 
     // Wait for the 'allFunctionsGenerated' event, which now waits for all executions
     await allFunctionsGeneratedPromise;
+  }
+  public generateNewImplementationsForCriteria(criteriaID: EvalCriteriaUID): void {
+    const crit = this.evalCriteria.find((c) => c.uid === criteriaID);
+    if (!crit) {
+      throw new Error(`Criteria with ID ${criteriaID} not found.`);
+    }
+    this.criteriaQueue.push(crit);
+    if (!this.processing) {
+      this.processNextCriteria();
+    }
+  }
+
+
+  /**
+   * Adds another evaluation criteria and triggers the generation and execution of evaluation functions for the new criteria.
+   * This method allows the client to add new evaluation criteria after the executor has been initialized.
+   * The new criteria will be processed in parallel with the existing criteria.
+   * The method returns immediately, allowing the client to continue with other tasks.
+   *  
+   * @param criteria The new evaluation criteria to be added.
+   */
+  public addCriteria(criteriaList: EvalCriteria[]): void {
+    // See if there are new criteria to add
+    for (const criteria of criteriaList) {
+      if (this.evalCriteria.includes(criteria)) {
+        continue;
+      }
+
+      console.log(`Adding new criteria: ${criteria.shortname}`);
+      this.criteriaQueue.push(criteria);
+      this.evalCriteria.push(criteria);
+    
+      // Start the generation and execution of functions for the new criteria
+      if (!this.processing) {
+        this.processNextCriteria();
+      }
+    }
+
+    // See if there are criteria to remove
+    for (const criteria of this.evalCriteria) {
+      if (!criteriaList.includes(criteria)) {
+        console.log(`Removing criteria: ${criteria.shortname}`);
+        this.evalCriteria = this.evalCriteria.filter((c) => c !== criteria);
+      }
+    }
+  }
+
+  private async processNextCriteria() {
+    // TODO: use worker pool to parallelize this
+    this.processing = true;
+    while (this.criteriaQueue.length > 0) {
+      const criteria = this.criteriaQueue.shift();
+      if (criteria) {
+        await this.generateAndExecuteFunctionsForCriteria(criteria);
+      }
+    }
+    this.processing = false;
   }
 
   /**
@@ -341,12 +486,57 @@ export default class EvaluationFunctionExecutor {
   /**
    * Sets a grade for an example based on external input from the developer.
    * This will be used for filtering out incorrect evaluation functions.
+   * If the developer does not provide a holistic grade, the executor will infer it from the perCriteriaGrades.
+   * With some probability, generate new implementations for the criteria in perCriteriaGrades.
    *
    * @param exampleId The unique ID of the example being graded.
-   * @param grade The developer-provided grade assigned to the example.
+   * @param holisticGrade The developer-provided grade assigned to the example, "good" or "bad" or unknown.
    */
-  public setGradeForExample(exampleId: ResponseUID, grade: boolean): void {
-    this.grades.set(exampleId, grade);
+  public setGradeForExample(exampleId: ResponseUID, perCriteriaGrades?: Dict<boolean | undefined>, holisticGrade?: string, annotation?: string ): number {
+    if (holisticGrade !== null) {
+      const boolHolistic = holisticGrade === "good" ? true : false;
+      this.grades.set(exampleId, boolHolistic);
+    }
+
+    if (perCriteriaGrades !== null) {
+      this.perCriteriaGrades[exampleId] = perCriteriaGrades;
+
+      // If holisticGrade was null, set it based on the perCriteriaGrades---if all criteria in the perCriteriaGrades are true, set the holisticGrade to true, else false
+      if (holisticGrade === null) {
+        const allTrue = Object.values(perCriteriaGrades).every(value => value === true);
+        this.grades.set(exampleId, allTrue);
+      }
+    }
+
+    if (annotation !== null) {
+      this.annotations[exampleId] = annotation;
+    }
+
+    let numCriteriaWithNewImplementations = 0;
+
+    // Trigger generateNewImplementationsForCriteria for each criteria in perCriteriaGrades
+    for (const criteriaId in perCriteriaGrades) {
+      const currGrade = perCriteriaGrades[criteriaId];
+      // With probability 1 / # graded examples for this criteria with currGrade, generate new implementations
+      const numGradedAsCurrGrade = this.examples.filter(example => this.perCriteriaGrades[example.uid] && this.perCriteriaGrades[example.uid][criteriaId] === currGrade).length;
+
+      if (Math.random() <= 1 / (numGradedAsCurrGrade + 1)) {
+        console.log(`Generating new implementations for criteria: ${criteriaId}`);
+        const evalCriteria = this.evalCriteria.find(criteria => criteria.uid === criteriaId);
+        if (evalCriteria) {
+          this.criteriaQueue.push(evalCriteria);
+          if (!this.processing) {
+            this.processNextCriteria();
+          }
+          numCriteriaWithNewImplementations++;
+        } else {
+          console.error(`Evaluation criteria with ID ${criteriaId} not found.`);
+        }
+      }
+    }
+
+    console.log(`Generated new implementations for ${numCriteriaWithNewImplementations} criteria.`);
+    return numCriteriaWithNewImplementations;
   }
 
   /**

--- a/chainforge/react-server/src/backend/evalgen/oai_utils.ts
+++ b/chainforge/react-server/src/backend/evalgen/oai_utils.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "events";
 import { get_openai_api_key } from "../utils";
 type ContentType = "criteria" | "python_fn" | "llm_eval";
 
-export class AzureOpenAIStreamer extends EventEmitter {
+export class OpenAIStreamer extends EventEmitter {
   private buffer = "";
   private isJsonContentStarted = false;
   private isPythonContentStarted = false;

--- a/chainforge/react-server/src/backend/evalgen/typing.ts
+++ b/chainforge/react-server/src/backend/evalgen/typing.ts
@@ -1,10 +1,12 @@
 import { ChatHistoryInfo, Dict } from "../typing";
 
+export type EvalCriteriaUID = string;
+
 export interface EvalCriteria {
   shortname: string;
   criteria: string;
   eval_method: "code" | "expert";
-  uid: string;
+  uid: EvalCriteriaUID;
   priority: number;
   source?: string;
 }


### PR DESCRIPTION
This PR:

* Generates criteria upon launch of the evalgen modal
* Stores per-criteria grades, annotations, and holistic grades
* Is more conservative when creating new criteria based on new annotations (we edit the prompt to only generate a new criterion if the annotation is not already encompassed by existing criteria, and it indicates a new failure mode--so annotations like "this is good" don't trigger new criteria)
* Triggers new implementations of eval functions occasionally on new graded responses
* Triggers new implementations of eval functions whenever new criteria is added
* Uses one good and one bad example response as few-shot examples in LLM evaluator prompts
* On hover over next, shows an estimate of new LLM calls
* Shows logs of how many LLM calls we are making in the backend

Things we need to do:

* Have a "finish" button that goes to the report card screen
* Include the report card from evalgen v1