### PR TITLE
Integrates the Evalgen Backend with Report Card and Multi-Eval Node.

### DIFF
--- a/chainforge/react-server/src/EvalGenModal.tsx
+++ b/chainforge/react-server/src/EvalGenModal.tsx
@@ -536,13 +536,21 @@ const EvalGenModal = forwardRef<EvalGenModalRef, NonNullable<unknown>>(
         const addLog = (message: string) => {
           setLogs((prevLogs) => [...prevLogs, { date: new Date(), message }]);
         };
+<<<<<<< HEAD
+=======
+
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
 
         const ex = new EvaluationFunctionExecutor(
           getLikelyPromptTemplateAsContext(responses),
           responses,
           criteria,
+<<<<<<< HEAD
           (gpt4Calls, gpt35Calls) => {
             // Callback to update GPT call counts
+=======
+          (gpt4Calls, gpt35Calls) => {  // Callback to update GPT call counts
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
             setNumGPT4Calls((num) => num + gpt4Calls);
             setNumGPT35Calls((num) => num + gpt35Calls);
           },
@@ -767,17 +775,26 @@ If you determine the feedback corresponds to a new criteria, your response shoul
       // Update annotation for current response (if any)
       // TODO: Fix this for generate case when num resp per prompt > 1
 
+<<<<<<< HEAD
       if (
         grades[shownResponse.uid] ||
         holisticGrade ||
         (annotation && annotation.trim())
       ) {
+=======
+      if (grades[shownResponse.uid] || holisticGrade || (annotation && annotation.trim())) {
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
         executor?.setGradeForExample(
           shownResponse.uid,
           grades[shownResponse.uid],
           holisticGrade,
+<<<<<<< HEAD
           annotation ? annotation.trim() : null,
         );
+=======
+          annotation ? annotation.trim() : null
+        ); 
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
       }
 
       if (
@@ -854,6 +871,7 @@ If you determine the feedback corresponds to a new criteria, your response shoul
       updateShownResponseUniqueIndex();
     };
 
+<<<<<<< HEAD
     const updateShownResponseUniqueIndex = () => {
       let idx = 0;
       for (const resp of responses) {
@@ -884,10 +902,13 @@ If you determine the feedback corresponds to a new criteria, your response shoul
       setShownResponse(responses[shownResponseIdx]);
     }, [shownResponseIdx]);
 
+=======
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
     const estimateGPTCalls = () => {
       return executor
         ? `This will trigger around ${executor.estimateNumGPTCalls(grades[shownResponse?.uid]).numGPT4Calls} GPT-4o and ${executor.estimateNumGPTCalls(grades[shownResponse?.uid]).numGPT35Calls} GPT-3.5-turbo-16k calls.`
         : "# estimated GPT calls not available.";
+<<<<<<< HEAD
     };
 
     const updateCriteriaForDisplay = () => {
@@ -907,6 +928,9 @@ If you determine the feedback corresponds to a new criteria, your response shoul
     };
 
     // const [onFinish, setOnFinish] = useState(null);
+=======
+    }
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
 
     return (
       <Modal
@@ -917,6 +941,7 @@ If you determine the feedback corresponds to a new criteria, your response shoul
         closeOnClickOutside={true}
         style={{ position: "relative", left: "-5%" }}
       >
+<<<<<<< HEAD
         {screen === "response" && (
           <Grid h={window?.innerHeight * 0.8}>
             <Grid.Col span={8}>
@@ -935,6 +960,21 @@ If you determine the feedback corresponds to a new criteria, your response shoul
                   estimateGPTCalls={estimateGPTCalls}
                   gotoNextScreen={gotoNextScreen}
                 />
+=======
+        <Grid h={window?.innerHeight * 0.8}>
+          <Grid.Col span={8}>
+            <Stack justify="space-between">
+              {/* View showing the response the user is currently grading */}
+              <GradingView
+                shownResponse={shownResponse}
+                numGPT4Calls={numGPT4Calls}
+                numGPT35Calls={numGPT35Calls}
+                logs={logs}
+                gotoNextResponse={nextResponse}
+                gotoPrevResponse={prevResponse}
+                estimateGPTCalls={estimateGPTCalls}
+              />
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
 
                 {/* Progress bar */}
                 {/* <Flex justify="left" align="center" gap="md">
@@ -1146,28 +1186,40 @@ const HeaderText = ({ children }: { children: ReactNode }) => {
 
 interface GradingViewProps {
   shownResponse: LLMResponse | undefined;
+<<<<<<< HEAD
   shownResponseIdx: number;
   responseCount: number;
+=======
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
   numGPT4Calls: number;
   numGPT35Calls: number;
   logs: { date: Date; message: string }[];
   gotoPrevResponse: () => void;
   gotoNextResponse: () => void;
   estimateGPTCalls: () => string;
+<<<<<<< HEAD
   gotoNextScreen: (screenName: string) => void;
+=======
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
 }
 
 const GradingView: React.FC<GradingViewProps> = ({
   shownResponse,
+<<<<<<< HEAD
   shownResponseIdx,
   responseCount,
+=======
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
   numGPT4Calls,
   numGPT35Calls,
   logs,
   gotoPrevResponse,
   gotoNextResponse,
   estimateGPTCalls,
+<<<<<<< HEAD
   gotoNextScreen,
+=======
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
 }) => {
   // Calculate inner values only when shownResponse changes
   const responseText = useMemo(
@@ -1257,7 +1309,16 @@ const GradingView: React.FC<GradingViewProps> = ({
           </div>
 
           {/* Go forward to the next response */}
+<<<<<<< HEAD
           <Tooltip label={estimateGPTCalls()} withArrow>
+=======
+          <Tooltip
+            label={
+              estimateGPTCalls()
+            }
+            withArrow
+          >
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
             <Button variant="white" color="dark" onClick={gotoNextResponse}>
               <IconChevronRight />
             </Button>
@@ -1306,6 +1367,7 @@ const GradingView: React.FC<GradingViewProps> = ({
         </Flex>
         <Flex direction="column">
           <Flex justify="space-between" align="center">
+<<<<<<< HEAD
             <Text size="lg" weight={500} mb="sm">
               LLM Activity
             </Text>
@@ -1313,10 +1375,17 @@ const GradingView: React.FC<GradingViewProps> = ({
             <Text size="sm" color="dark" style={{ fontStyle: "italic" }}>
               Executed {numGPT4Calls} GPT-4o calls and {numGPT35Calls}{" "}
               GPT-3.5-Turbo-16k calls.
+=======
+            <Text size="lg" weight={500} mb="sm">LLM Activity</Text>
+            {/* GPT Call Tally */}
+            <Text size="sm" color="dark" style={{ fontStyle: "italic" }}>
+              Executed {numGPT4Calls} GPT-4o calls and {numGPT35Calls} GPT-3.5-Turbo-16k calls.
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
             </Text>
           </Flex>
           <div
             style={{
+<<<<<<< HEAD
               backgroundColor: "#f0f0f0",
               color: "#333",
               fontFamily: "monospace",
@@ -1326,6 +1395,17 @@ const GradingView: React.FC<GradingViewProps> = ({
               overflowY: "auto",
               borderRadius: "8px",
               border: "1px solid #ddd",
+=======
+              backgroundColor: "#f0f0f0", 
+              color: "#333",
+              fontFamily: "monospace",
+              padding: "12px",
+              width: "calc(100% - 30px)", 
+              height: "200px",
+              overflowY: "auto",
+              borderRadius: "8px",
+              border: "1px solid #ddd", 
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
               marginRight: "20px", // Space on the right
             }}
             ref={(el) => {
@@ -1336,9 +1416,13 @@ const GradingView: React.FC<GradingViewProps> = ({
           >
             {logs.map((log, index) => (
               <div key={index}>
+<<<<<<< HEAD
                 <span style={{ color: "#4A90E2" }}>
                   {log.date.toLocaleString()} -{" "}
                 </span>
+=======
+                <span style={{ color: '#4A90E2' }}>{log.date.toLocaleString()} - </span> 
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
                 <span>{log.message}</span>
               </div>
             ))}

--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -58,6 +58,7 @@ const ChatGPTSettings: ModelSettingsDict = {
           "gpt-3.5-turbo",
           "gpt-4-turbo",
           "gpt-4o",
+          "gpt-4o-mini",
           "gpt-4",
           "gpt-4-turbo-2024-04-09",
           "gpt-4-turbo-preview",

--- a/chainforge/react-server/src/MultiEvalNode.tsx
+++ b/chainforge/react-server/src/MultiEvalNode.tsx
@@ -60,10 +60,9 @@ import { Dict, LLMResponse, QueryProgress } from "./backend/typing";
 import { AlertModalContext } from "./AlertModal";
 import { Status } from "./StatusIndicatorComponent";
 import EvalGenModal, {
-  EvalGenModalRef,
-  ReportCardScreen,
+  EvalGenModalRef
 } from "./EvalGenModal";
-import { EvalGenReport } from "./backend/evalgen/typing";
+import { EvalFunction } from "./backend/evalgen/typing";
 
 const IS_RUNNING_LOCALLY = APP_IS_RUNNING_LOCALLY();
 
@@ -663,32 +662,33 @@ const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
     evalGenModalRef.current?.trigger(resps, onFinalReportsReady);
   };
 
-  const onFinalReportsReady = (reports: EvalGenReport) => {
+
+  const onFinalReportsReady = (selectedFunctions: EvalFunction[]) => {
     // Placeholder for process the final reports returned from EvalGenModel
-    console.log("!!!!!!!!!!!!!!!!!!!!!!!!!! final reports", reports);
+    console.log("!!!!!!!!!!!!!!!!!!!!!!!!!! final functions", selectedFunctions);
     // let kkk = 1;
-    for (const crit of reports.criteria) {
+    for (const func of selectedFunctions) {
       // setTimeout(() => {
       // console.log("crit", crit);
-      if (crit.eval_method === "code") {
+      if (func.evalCriteria.eval_method === "code") {
         // Python
         addEvaluator(
-          crit.shortname,
+          func.evalCriteria.shortname,
           "python",
           {
-            code: "def evaluate(r):\n\treturn len(r.text)", // to be populated once python code is implemented for the criteria
+            code: func.code, // to be populated once python code is implemented for the criteria
             sandbox: true,
           },
           false,
         );
-      } else if (crit.eval_method === "expert") {
+      } else if (func.evalCriteria.eval_method === "expert") {
         // LLM
         addEvaluator(
-          crit.shortname,
+          func.evalCriteria.shortname,
           "llm",
           {
             // to be populated once LLM code is implemented for the criteria
-            prompt: "",
+            prompt: func.code,
             format: "bin",
           },
           false,
@@ -696,10 +696,10 @@ const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
       } else {
         // JavaScript
         addEvaluator(
-          crit.shortname,
+          func.evalCriteria.shortname,
           "javascript",
           {
-            code: "function evaluate(r) {\n\treturn r.text.length;\n}", // to be populated once javascript code is implemented for the criteria
+            code: func.code,
           },
           false,
         );

--- a/chainforge/react-server/src/backend/evalgen/executor.ts
+++ b/chainforge/react-server/src/backend/evalgen/executor.ts
@@ -197,6 +197,7 @@ export default class EvaluationFunctionExecutor {
     const functionExecutionPromises: Promise<any>[] = [];
 
     emitter.on("functionGenerated", (evalFunction) => {
+
       const executionPromise = (async () => {
         this.evalFunctions.push(evalFunction);
         const executionPromises = this.examples.map(async (example) => {
@@ -228,6 +229,11 @@ export default class EvaluationFunctionExecutor {
             this.updateGPTCalls(0, 1);
           }
 
+          // Update GPT-3.5 call count by 1 if the eval method is expert
+          if (evalFunction.evalCriteria.eval_method === "expert") {
+            this.updateGPTCalls(0, 1);
+          }
+
           if (onProgress) {
             onProgress({
               success:
@@ -253,11 +259,17 @@ export default class EvaluationFunctionExecutor {
       functionExecutionPromises.push(executionPromise);
     });
 
+<<<<<<< HEAD
     const badExample = this.examples.find(
       (example) =>
         this.perCriteriaGrades[criteria.uid]?.[example.uid] === false,
     );
 
+=======
+    const badExample = this.examples.find(example => this.perCriteriaGrades[criteria.uid]?.[example.uid] === false);
+
+  
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
     await generateFunctionsForCriteria(
       criteria,
       this.promptTemplate,
@@ -269,12 +281,17 @@ export default class EvaluationFunctionExecutor {
     this.updateGPTCalls(1, 0);
 
     console.log(`Generated functions for criteria: ${criteria.shortname}`);
+<<<<<<< HEAD
     console.log(
       `Number of functions generated: ${functionExecutionPromises.length}`,
     );
     this.logFunction(
       `Generated ${functionExecutionPromises.length} functions for criteria: ${criteria.shortname}`,
     );
+=======
+    console.log(`Number of functions generated: ${functionExecutionPromises.length}`);
+    this.logFunction(`Generated ${functionExecutionPromises.length} functions for criteria: ${criteria.shortname}`);
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
 
     await Promise.all(functionExecutionPromises);
   }
@@ -308,9 +325,13 @@ export default class EvaluationFunctionExecutor {
 
     // Listen for generated functions and execute them as they come in
     emitter.on("functionGenerated", (evalFunction) => {
+<<<<<<< HEAD
       this.logFunction(
         `Generated a new ${evalFunction.evalCriteria.eval_method === "code" ? "code-based" : "LLM-based"} validator for criteria: ${evalFunction.evalCriteria.shortname}${evalFunction.evalCriteria.eval_method === "expert" ? `, with prompt: ${evalFunction.name}` : ""}. Executing it on ${this.examples.length} examples.`,
       );
+=======
+      this.logFunction(`Generated a new ${evalFunction.evalCriteria.eval_method === "code" ? "code-based" : "LLM-based"} validator for criteria: ${evalFunction.evalCriteria.shortname}${evalFunction.evalCriteria.eval_method === "expert" ? `, with prompt: ${evalFunction.name}` : ""}. Executing it on ${this.examples.length} examples.`);
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
 
       // Capture the execution promise of each function
       const executionPromise = (async () => {
@@ -341,6 +362,11 @@ export default class EvaluationFunctionExecutor {
             randomPositiveExample,
             randomNegativeExample,
           );
+
+          // Update GPT-3.5 call count by 1 if the eval method is expert
+          if (evalFunction.evalCriteria.eval_method === "expert") {
+            this.updateGPTCalls(0, 1);
+          }
 
           // Update GPT-3.5 call count by 1 if the eval method is expert
           if (evalFunction.evalCriteria.eval_method === "expert") {
@@ -398,9 +424,13 @@ export default class EvaluationFunctionExecutor {
           console.log(
             "All evaluation functions have been generated and executed.",
           );
+<<<<<<< HEAD
           this.logFunction(
             "All initially-generated evaluation functions have been generated and executed.",
           );
+=======
+          this.logFunction("All initially-generated evaluation functions have been generated and executed.");
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
           if (resolveAllFunctionsGenerated) {
             resolveAllFunctionsGenerated(); // Resolve the promise when all functions have been generated and executed
           }
@@ -541,14 +571,20 @@ export default class EvaluationFunctionExecutor {
     return new Map(this.grades);
   }
 
+<<<<<<< HEAD
   public estimateNumGPTCalls(perCriteriaGrades: Dict<boolean>): {
     numGPT4Calls: number;
     numGPT35Calls: number;
   } {
+=======
+  public estimateNumGPTCalls(perCriteriaGrades: Dict<boolean>): { numGPT4Calls: number; numGPT35Calls: number }{
+
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
     let numGPT4Calls = 0;
     let numLLMCriteria = 0;
     for (const criteriaId in perCriteriaGrades) {
       const currGrade = perCriteriaGrades[criteriaId];
+<<<<<<< HEAD
       const numGradedAsCurrGrade = this.examples.filter(
         (example) =>
           this.perCriteriaGrades[example.uid] &&
@@ -559,6 +595,12 @@ export default class EvaluationFunctionExecutor {
         const criteria = this.evalCriteria.find(
           (criteria) => criteria.uid === criteriaId,
         );
+=======
+      const numGradedAsCurrGrade = this.examples.filter(example => this.perCriteriaGrades[example.uid] && this.perCriteriaGrades[example.uid][criteriaId] === currGrade).length;
+      if (Math.random() <= 1 / (numGradedAsCurrGrade + 1)) {
+        numGPT4Calls += 1;
+        const criteria = this.evalCriteria.find(criteria => criteria.uid === criteriaId);
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
         if (criteria && criteria.eval_method === "expert") {
           numLLMCriteria += 1;
         }
@@ -566,9 +608,16 @@ export default class EvaluationFunctionExecutor {
     }
 
     return {
+<<<<<<< HEAD
       numGPT4Calls,
       numGPT35Calls: numLLMCriteria * 3 * this.examples.length,
     };
+=======
+      numGPT4Calls: numGPT4Calls,
+      numGPT35Calls: numLLMCriteria * 3 * this.examples.length,
+    };
+
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
   }
 
   /**
@@ -580,12 +629,16 @@ export default class EvaluationFunctionExecutor {
    * @param exampleId The unique ID of the example being graded.
    * @param holisticGrade The developer-provided grade assigned to the example, "good" or "bad" or unknown.
    */
+<<<<<<< HEAD
   public setGradeForExample(
     exampleId: ResponseUID,
     perCriteriaGrades?: Dict<boolean | undefined>,
     holisticGrade?: string,
     annotation?: string,
   ): void {
+=======
+  public setGradeForExample(exampleId: ResponseUID, perCriteriaGrades?: Dict<boolean | undefined>, holisticGrade?: string, annotation?: string ): void {
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
     if (holisticGrade !== null) {
       const boolHolistic = holisticGrade === "good";
       this.grades.set(exampleId, boolHolistic);
@@ -638,9 +691,13 @@ export default class EvaluationFunctionExecutor {
       }
     }
 
+<<<<<<< HEAD
     console.log(
       `Generated new implementations for ${numCriteriaWithNewImplementations} criteria.`,
     );
+=======
+    console.log(`Generated new implementations for ${numCriteriaWithNewImplementations} criteria.`);
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
   }
 
   /**

--- a/chainforge/react-server/src/backend/evalgen/executor.ts
+++ b/chainforge/react-server/src/backend/evalgen/executor.ts
@@ -145,8 +145,6 @@ export default class EvaluationFunctionExecutor {
     this.logFunction = addLog;
   }
 
-
-
   /**
    * Starts the background computation for generating and executing evaluation functions.
    * This method initiates the tasks but does not wait for them to complete.
@@ -197,7 +195,6 @@ export default class EvaluationFunctionExecutor {
     const functionExecutionPromises: Promise<any>[] = [];
 
     emitter.on("functionGenerated", (evalFunction) => {
-
       const executionPromise = (async () => {
         this.evalFunctions.push(evalFunction);
         const executionPromises = this.examples.map(async (example) => {
@@ -229,11 +226,6 @@ export default class EvaluationFunctionExecutor {
             this.updateGPTCalls(0, 1);
           }
 
-          // Update GPT-3.5 call count by 1 if the eval method is expert
-          if (evalFunction.evalCriteria.eval_method === "expert") {
-            this.updateGPTCalls(0, 1);
-          }
-
           if (onProgress) {
             onProgress({
               success:
@@ -259,17 +251,11 @@ export default class EvaluationFunctionExecutor {
       functionExecutionPromises.push(executionPromise);
     });
 
-<<<<<<< HEAD
     const badExample = this.examples.find(
       (example) =>
         this.perCriteriaGrades[criteria.uid]?.[example.uid] === false,
     );
 
-=======
-    const badExample = this.examples.find(example => this.perCriteriaGrades[criteria.uid]?.[example.uid] === false);
-
-  
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
     await generateFunctionsForCriteria(
       criteria,
       this.promptTemplate,
@@ -281,17 +267,12 @@ export default class EvaluationFunctionExecutor {
     this.updateGPTCalls(1, 0);
 
     console.log(`Generated functions for criteria: ${criteria.shortname}`);
-<<<<<<< HEAD
     console.log(
       `Number of functions generated: ${functionExecutionPromises.length}`,
     );
     this.logFunction(
       `Generated ${functionExecutionPromises.length} functions for criteria: ${criteria.shortname}`,
     );
-=======
-    console.log(`Number of functions generated: ${functionExecutionPromises.length}`);
-    this.logFunction(`Generated ${functionExecutionPromises.length} functions for criteria: ${criteria.shortname}`);
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
 
     await Promise.all(functionExecutionPromises);
   }
@@ -325,13 +306,9 @@ export default class EvaluationFunctionExecutor {
 
     // Listen for generated functions and execute them as they come in
     emitter.on("functionGenerated", (evalFunction) => {
-<<<<<<< HEAD
       this.logFunction(
         `Generated a new ${evalFunction.evalCriteria.eval_method === "code" ? "code-based" : "LLM-based"} validator for criteria: ${evalFunction.evalCriteria.shortname}${evalFunction.evalCriteria.eval_method === "expert" ? `, with prompt: ${evalFunction.name}` : ""}. Executing it on ${this.examples.length} examples.`,
       );
-=======
-      this.logFunction(`Generated a new ${evalFunction.evalCriteria.eval_method === "code" ? "code-based" : "LLM-based"} validator for criteria: ${evalFunction.evalCriteria.shortname}${evalFunction.evalCriteria.eval_method === "expert" ? `, with prompt: ${evalFunction.name}` : ""}. Executing it on ${this.examples.length} examples.`);
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
 
       // Capture the execution promise of each function
       const executionPromise = (async () => {
@@ -362,11 +339,6 @@ export default class EvaluationFunctionExecutor {
             randomPositiveExample,
             randomNegativeExample,
           );
-
-          // Update GPT-3.5 call count by 1 if the eval method is expert
-          if (evalFunction.evalCriteria.eval_method === "expert") {
-            this.updateGPTCalls(0, 1);
-          }
 
           // Update GPT-3.5 call count by 1 if the eval method is expert
           if (evalFunction.evalCriteria.eval_method === "expert") {
@@ -424,13 +396,9 @@ export default class EvaluationFunctionExecutor {
           console.log(
             "All evaluation functions have been generated and executed.",
           );
-<<<<<<< HEAD
           this.logFunction(
             "All initially-generated evaluation functions have been generated and executed.",
           );
-=======
-          this.logFunction("All initially-generated evaluation functions have been generated and executed.");
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
           if (resolveAllFunctionsGenerated) {
             resolveAllFunctionsGenerated(); // Resolve the promise when all functions have been generated and executed
           }
@@ -447,7 +415,10 @@ export default class EvaluationFunctionExecutor {
     // Wait for the 'allFunctionsGenerated' event, which now waits for all executions
     await allFunctionsGeneratedPromise;
   }
-  public generateNewImplementationsForCriteria(criteriaID: EvalCriteriaUID): void {
+
+  public generateNewImplementationsForCriteria(
+    criteriaID: EvalCriteriaUID,
+  ): void {
     const crit = this.evalCriteria.find((c) => c.uid === criteriaID);
     if (!crit) {
       throw new Error(`Criteria with ID ${criteriaID} not found.`);
@@ -457,7 +428,6 @@ export default class EvaluationFunctionExecutor {
       this.processNextCriteria();
     }
   }
-
 
   /**
    * Adds another evaluation criteria and triggers the generation and execution of evaluation functions for the new criteria.
@@ -571,20 +541,14 @@ export default class EvaluationFunctionExecutor {
     return new Map(this.grades);
   }
 
-<<<<<<< HEAD
   public estimateNumGPTCalls(perCriteriaGrades: Dict<boolean>): {
     numGPT4Calls: number;
     numGPT35Calls: number;
   } {
-=======
-  public estimateNumGPTCalls(perCriteriaGrades: Dict<boolean>): { numGPT4Calls: number; numGPT35Calls: number }{
-
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
     let numGPT4Calls = 0;
     let numLLMCriteria = 0;
     for (const criteriaId in perCriteriaGrades) {
       const currGrade = perCriteriaGrades[criteriaId];
-<<<<<<< HEAD
       const numGradedAsCurrGrade = this.examples.filter(
         (example) =>
           this.perCriteriaGrades[example.uid] &&
@@ -595,12 +559,6 @@ export default class EvaluationFunctionExecutor {
         const criteria = this.evalCriteria.find(
           (criteria) => criteria.uid === criteriaId,
         );
-=======
-      const numGradedAsCurrGrade = this.examples.filter(example => this.perCriteriaGrades[example.uid] && this.perCriteriaGrades[example.uid][criteriaId] === currGrade).length;
-      if (Math.random() <= 1 / (numGradedAsCurrGrade + 1)) {
-        numGPT4Calls += 1;
-        const criteria = this.evalCriteria.find(criteria => criteria.uid === criteriaId);
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
         if (criteria && criteria.eval_method === "expert") {
           numLLMCriteria += 1;
         }
@@ -608,16 +566,9 @@ export default class EvaluationFunctionExecutor {
     }
 
     return {
-<<<<<<< HEAD
       numGPT4Calls,
       numGPT35Calls: numLLMCriteria * 3 * this.examples.length,
     };
-=======
-      numGPT4Calls: numGPT4Calls,
-      numGPT35Calls: numLLMCriteria * 3 * this.examples.length,
-    };
-
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
   }
 
   /**
@@ -629,16 +580,12 @@ export default class EvaluationFunctionExecutor {
    * @param exampleId The unique ID of the example being graded.
    * @param holisticGrade The developer-provided grade assigned to the example, "good" or "bad" or unknown.
    */
-<<<<<<< HEAD
   public setGradeForExample(
     exampleId: ResponseUID,
     perCriteriaGrades?: Dict<boolean | undefined>,
     holisticGrade?: string,
     annotation?: string,
   ): void {
-=======
-  public setGradeForExample(exampleId: ResponseUID, perCriteriaGrades?: Dict<boolean | undefined>, holisticGrade?: string, annotation?: string ): void {
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
     if (holisticGrade !== null) {
       const boolHolistic = holisticGrade === "good";
       this.grades.set(exampleId, boolHolistic);
@@ -691,13 +638,9 @@ export default class EvaluationFunctionExecutor {
       }
     }
 
-<<<<<<< HEAD
     console.log(
       `Generated new implementations for ${numCriteriaWithNewImplementations} criteria.`,
     );
-=======
-    console.log(`Generated new implementations for ${numCriteriaWithNewImplementations} criteria.`);
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
   }
 
   /**

--- a/chainforge/react-server/src/backend/evalgen/executor.ts
+++ b/chainforge/react-server/src/backend/evalgen/executor.ts
@@ -145,6 +145,8 @@ export default class EvaluationFunctionExecutor {
     this.logFunction = addLog;
   }
 
+
+
   /**
    * Starts the background computation for generating and executing evaluation functions.
    * This method initiates the tasks but does not wait for them to complete.
@@ -415,10 +417,7 @@ export default class EvaluationFunctionExecutor {
     // Wait for the 'allFunctionsGenerated' event, which now waits for all executions
     await allFunctionsGeneratedPromise;
   }
-
-  public generateNewImplementationsForCriteria(
-    criteriaID: EvalCriteriaUID,
-  ): void {
+  public generateNewImplementationsForCriteria(criteriaID: EvalCriteriaUID): void {
     const crit = this.evalCriteria.find((c) => c.uid === criteriaID);
     if (!crit) {
       throw new Error(`Criteria with ID ${criteriaID} not found.`);
@@ -428,6 +427,7 @@ export default class EvaluationFunctionExecutor {
       this.processNextCriteria();
     }
   }
+
 
   /**
    * Adds another evaluation criteria and triggers the generation and execution of evaluation functions for the new criteria.

--- a/chainforge/react-server/src/backend/evalgen/typing.ts
+++ b/chainforge/react-server/src/backend/evalgen/typing.ts
@@ -11,12 +11,6 @@ export interface EvalCriteria {
   source?: string;
 }
 
-export interface EvalGenReport {
-  criteria: EvalCriteria[];
-  failureCoverage: number;
-  falseFailureRate: number;
-}
-
 export function validEvalCriteriaFormat(json_obj: Dict) {
   return (
     "criteria" in json_obj &&

--- a/chainforge/react-server/src/backend/evalgen/utils.ts
+++ b/chainforge/react-server/src/backend/evalgen/utils.ts
@@ -282,7 +282,11 @@ export async function generateFunctionsForCriteria(
     criteria,
     promptTemplate,
     example,
+<<<<<<< HEAD
     badExample,
+=======
+    badExample
+>>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
   );
   console.log("Function generation prompt:", functionGenPrompt);
 

--- a/chainforge/react-server/src/backend/evalgen/utils.ts
+++ b/chainforge/react-server/src/backend/evalgen/utils.ts
@@ -113,8 +113,8 @@ export async function generateLLMEvaluationCriteria(
 export async function executeLLMEval(
   evalFunction: EvalFunction,
   example: LLMResponse,
-  positiveExample: LLMResponse,
-  negativeExample: LLMResponse,
+  positiveExample?: LLMResponse,
+  negativeExample?: LLMResponse,
 ): Promise<EvalFunctionResult> {
   // Construct call to an LLM to evaluate the example
   const evalPrompt =
@@ -147,7 +147,7 @@ export async function executeLLMEval(
 
   const result = await simpleQueryLLM(
     evalPrompt, // prompt
-    "gpt-3.5-turbo-16k", // llm
+    "gpt-4o-mini", // llm
     systemMessage, // system_msg
   );
   // Get the output
@@ -220,8 +220,8 @@ export async function execJSFunc(
 export async function execPyFunc(
   evalFunction: EvalFunction,
   example: LLMResponse,
-  positiveExample: LLMResponse,
-  negativeExample: LLMResponse,
+  positiveExample?: LLMResponse,
+  negativeExample?: LLMResponse,
 ): Promise<EvalFunctionResult> {
   try {
     // We need to replace the function name with "evaluate", which is what is expected by backend:
@@ -282,11 +282,7 @@ export async function generateFunctionsForCriteria(
     criteria,
     promptTemplate,
     example,
-<<<<<<< HEAD
     badExample,
-=======
-    badExample
->>>>>>> c979cf1 (Adding UI indicators of how many LLM calls are executed)
   );
   console.log("Function generation prompt:", functionGenPrompt);
 

--- a/chainforge/react-server/src/backend/models.ts
+++ b/chainforge/react-server/src/backend/models.ts
@@ -22,6 +22,7 @@ export enum NativeLLM {
   OpenAI_GPT4_Turbo = "gpt-4-turbo",
   OpenAI_GPT4_Turbo_0409 = "gpt-4-turbo-2024-04-09",
   OpenAI_GPT4_O = "gpt-4o",
+  OpenAI_GPT4_O_mini = "gpt-4o-mini",
   OpenAI_GPT4_32k = "gpt-4-32k",
   OpenAI_GPT4_32k_0314 = "gpt-4-32k-0314",
   OpenAI_GPT4_32k_0613 = "gpt-4-32k-0613",


### PR DESCRIPTION
This PR integrates the backend (executor.ts) with the Report card, allowing users to select & inspect candidate implementations. The selected evals get propagated to the multi-eval node.

Things I haven't figured out:
* Not quite sure what the ring progress indicators are supposed to do.
* Saving grades in session storage. I think we can probably integrate something into the front end, so we have it for UIST, and then figure out how to save grades/persist beyond a single grading session.