### PR TITLE
GenAI Data Synthesis for Tabular Data Node

### DIFF
--- a/chainforge/react-server/src/AiPopover.tsx
+++ b/chainforge/react-server/src/AiPopover.tsx
@@ -10,12 +10,16 @@ import {
   Badge,
   Textarea,
   Alert,
+  Divider,
 } from "@mantine/core";
 import {
   autofill,
+  autofillTable,
+  generateColumn,
   generateAndReplace,
   AIError,
   getAIFeaturesModels,
+  generateAndReplaceTable,
 } from "./backend/ai";
 import { IconSparkles, IconAlertCircle } from "@tabler/icons-react";
 import { AlertModalContext } from "./AlertModal";
@@ -30,7 +34,13 @@ import { queryLLM } from "./backend/backend";
 import { splitText } from "./SplitNode";
 import { escapeBraces } from "./backend/template";
 import { cleanMetavarsFilterFunc } from "./backend/utils";
-import { Dict, VarsContext } from "./backend/typing";
+import {
+  Dict,
+  TabularDataColType,
+  TabularDataRowType,
+  VarsContext,
+} from "./backend/typing";
+import { v4 as uuidv4 } from "uuid";
 
 const zeroGap = { gap: "0rem" };
 const popoverShadow = "rgb(38, 57, 77) 0px 10px 30px -14px";
@@ -74,7 +84,7 @@ export const buildGenEvalCodePrompt = (
   specPrompt: string,
   manyFuncs?: boolean,
   onlyBooleanFuncs?: boolean,
-) => `You are to generate ${manyFuncs ? "many different functions" : "one function"} to evaluate textual data, given a user-specified specification. 
+) => `You are to generate ${manyFuncs ? "many different functions" : "one function"} to evaluate textual data, given a user-specified specification.
 The function${manyFuncs ? "s" : ""} will be mapped over an array of objects of type ResponseInfo.
 ${manyFuncs ? "Each" : "Your"} solution must contain a single function called 'evaluate' that takes a single object, 'r', of type ResponseInfo. A ResponseInfo is defined as:
 
@@ -84,8 +94,8 @@ For instance, here is an evaluator that returns the length of a response:
 
 \`\`\`${progLang === "javascript" ? INFO_EXAMPLE_JS : INFO_EXAMPLE_PY}\`\`\`
 
-You can only write in ${progLang.charAt(0).toUpperCase() + progLang.substring(1)}. 
-You ${progLang === "javascript" ? 'CANNOT import any external packages, and always use "let" to define variables instead of "var".' : "can use imports if necessary. Do not include any type hints."} 
+You can only write in ${progLang.charAt(0).toUpperCase() + progLang.substring(1)}.
+You ${progLang === "javascript" ? 'CANNOT import any external packages, and always use "let" to define variables instead of "var".' : "can use imports if necessary. Do not include any type hints."}
 Your function${manyFuncs ? "s" : ""} can ONLY return ${onlyBooleanFuncs ? "boolean" : "boolean, numeric, or string"} values.
 ${context}
 Here is the user's specification:
@@ -226,6 +236,336 @@ export function AIPopover({
   );
 }
 
+export interface AIGenReplaceTablePopoverProps {
+  // Values in the rows of the table's columns
+  values: TabularDataRowType[];
+  // Function to add new rows
+  onAddRows: (newRows: TabularDataRowType[]) => void;
+  // Function to replace the table
+  onReplaceTable: (
+    columns: TabularDataColType[],
+    rows: TabularDataRowType[],
+  ) => void;
+  // Function to add new columns
+  onAddColumns: (
+    newColumns: TabularDataColType[],
+    rowValues?: string[], // Optional row values
+  ) => void;
+  // Indicates if values are loading
+  areValuesLoading: boolean;
+  // Callback to set loading state
+  setValuesLoading: (isLoading: boolean) => void;
+}
+
+/**
+ * AI Popover UI for TablularData nodes
+ */
+export function AIGenReplaceTablePopover({
+  values,
+  onAddRows,
+  onReplaceTable,
+  onAddColumns,
+  areValuesLoading,
+  setValuesLoading,
+}: AIGenReplaceTablePopoverProps) {
+  // API keys and provider
+  const apiKeys = useStore((state) => state.apiKeys);
+  const aiFeaturesProvider = useStore((state) => state.aiFeaturesProvider);
+
+  // Alert context
+  const showAlert = useContext(AlertModalContext);
+
+  // Command Fill state
+  const [commandFillNumber, setCommandFillNumber] = useState<number>(3);
+  const [isCommandFillLoading, setIsCommandFillLoading] = useState(false);
+  const [didCommandFillError, setDidCommandFillError] = useState(false);
+
+  // Generate and Replace state
+  const [generateAndReplaceNumber, setGenerateAndReplaceNumber] = useState(3);
+  const [generateAndReplacePrompt, setGenerateAndReplacePrompt] = useState("");
+  const [genDiverseOutputs, setGenDiverseOutputs] = useState(false);
+  const [didGenerateAndReplaceTableError, setDidGenerateAndReplaceTableError] =
+    useState(false);
+
+  // Generate Column state
+  const [isGenerateColumnLoading, setIsGenerateColumnLoading] = useState(false);
+  const [generateColumnPrompt, setGenerateColumnPrompt] = useState("");
+  const [didGenerateColumnError, setDidGenerateColumnError] = useState(false);
+
+  // Check if there are any non-empty rows
+  const nonEmptyRows = useMemo(
+    () =>
+      values.filter((row) => Object.values(row).some((val) => val?.trim()))
+        .length,
+    [values],
+  );
+
+  // Check if there are enough rows to suggest autofilling
+  const enoughRowsForSuggestions = useMemo(
+    () => nonEmptyRows >= ROW_CONSTANTS.beginAutofilling,
+    [nonEmptyRows],
+  );
+
+  const showWarning = useMemo(
+    () => enoughRowsForSuggestions && nonEmptyRows < ROW_CONSTANTS.warnIfBelow,
+    [enoughRowsForSuggestions, nonEmptyRows],
+  );
+
+  const handleGenerateAndReplaceTable = async () => {
+    setDidGenerateAndReplaceTableError(false);
+    setValuesLoading(true);
+
+    try {
+      // Fetch the generated table
+      const generatedTable = await generateAndReplaceTable(
+        generateAndReplacePrompt,
+        generateAndReplaceNumber,
+        genDiverseOutputs,
+        aiFeaturesProvider,
+        apiKeys,
+      );
+
+      const { cols, rows } = generatedTable;
+
+      // Transform the result into TabularDataNode format
+      const columns = cols.map((col, index) => ({
+        key: `col-${index}`,
+        header: col,
+      }));
+
+      const tabularRows = rows.map((row) => {
+        const rowData: TabularDataRowType = { __uid: uuidv4() };
+        cols.forEach((col, index) => {
+          rowData[`col-${index}`] = row.split(" | ")[index]?.trim() || "";
+        });
+        return rowData;
+      });
+
+      // Update state with the transformed columns and rows
+      onReplaceTable(columns, tabularRows);
+
+      console.log("Generated table:", { columns, tabularRows });
+    } catch (error) {
+      console.error("Error in generateAndReplaceTable:", error);
+      setDidGenerateAndReplaceTableError(true);
+      showAlert && showAlert("An error occurred. Please try again.");
+    } finally {
+      setValuesLoading(false);
+    }
+  };
+
+  const handleCommandFill = async () => {
+    setIsCommandFillLoading(true);
+    setDidCommandFillError(false);
+
+    try {
+      // Extract columns from the values, excluding the __uid column
+      const tableColumns = Object.keys(values[0] || {}).filter(
+        (col) => col !== "__uid",
+      );
+
+      // Extract rows as strings, excluding the __uid column and handling empty rows
+      const tableRows = values
+        .slice(0, -1) // Remove the last empty row
+        .map((row) =>
+          tableColumns.map((col) => row[col]?.trim() || "").join(" | "),
+        );
+
+      const tableInput = {
+        cols: tableColumns,
+        rows: tableRows,
+      };
+
+      // Fetch new rows from the autofillTable function
+      const result = await autofillTable(
+        tableInput,
+        commandFillNumber,
+        aiFeaturesProvider,
+        apiKeys,
+      );
+
+      // Transform result.rows into TabularDataNode format
+      const newRows = result.rows.map((row) => {
+        const newRow: TabularDataRowType = { __uid: uuidv4() };
+        row.split(" | ").forEach((cell, index) => {
+          newRow[`col-${index}`] = cell;
+        });
+        return newRow;
+      });
+
+      // Append the new rows to the existing rows
+      onAddRows(newRows);
+    } catch (error) {
+      console.error("Error generating rows:", error);
+      setDidCommandFillError(true);
+      showAlert && showAlert("Failed to generate new rows. Please try again.");
+    } finally {
+      setIsCommandFillLoading(false);
+    }
+  };
+
+  const handleGenerateColumn = async () => {
+    setDidGenerateColumnError(false);
+    setIsGenerateColumnLoading(true);
+
+    try {
+      // Extract columns from the values, excluding the __uid column
+      const tableColumns = Object.keys(values[0] || {}).filter(
+        (col) => col !== "__uid",
+      );
+
+      // Extract rows as strings, excluding the __uid column and handling empty rows
+      const lastRow = values[values.length - 1]; // Get the last row
+      const emptyLastRow = Object.values(lastRow).every((val) => !val); // Check if the last row is empty
+      const tableRows = values
+        .slice(0, emptyLastRow ? -1 : values.length)
+        .map((row) =>
+          tableColumns.map((col) => row[col]?.trim() || "").join(" | "),
+        );
+
+      const tableInput = {
+        cols: tableColumns,
+        rows: tableRows,
+      };
+      // Fetch the generated column
+      const generatedColumn = await generateColumn(
+        tableInput,
+        generateColumnPrompt,
+        aiFeaturesProvider,
+        apiKeys,
+      );
+
+      const rowValues = generatedColumn.rows;
+
+      // Append the new column to the existing columns
+      onAddColumns(
+        [{ key: `col-${tableColumns.length}`, header: generatedColumn.col }], // set key to length of columns
+        rowValues,
+      );
+    } catch (error) {
+      console.error("Error generating column:", error);
+      setDidGenerateColumnError(true);
+      showAlert &&
+        showAlert("Failed to generate a new column. Please try again.");
+    } finally {
+      setIsGenerateColumnLoading(false);
+    }
+  };
+
+  const extendUI = (
+    <Stack>
+      {didCommandFillError && (
+        <Text size="xs" color="red">
+          Failed to generate rows. Please try again.
+        </Text>
+      )}
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <NumberInput
+          label="Rows to add"
+          mt={5}
+          min={1}
+          max={10}
+          value={commandFillNumber}
+          onChange={(num) => setCommandFillNumber(num || 1)}
+          style={{ flex: 1 }}
+        />
+        <Button
+          size="sm"
+          variant="light"
+          color="grape"
+          onClick={handleCommandFill}
+          disabled={!enoughRowsForSuggestions}
+          loading={isCommandFillLoading}
+          style={{ marginTop: "1.5rem", flex: 1 }}
+        >
+          Extend
+        </Button>
+      </div>
+      {showWarning && (
+        <Text size="xs" color="grape">
+          You may want to add more fields for better suggestions.
+        </Text>
+      )}
+      <Divider label="OR" labelPosition="center" />
+      {didGenerateColumnError && (
+        <Text size="xs" color="red">
+          Failed to generate column. Please try again.
+        </Text>
+      )}
+      <Textarea
+        label="Generate a column for..."
+        value={generateColumnPrompt}
+        onChange={(e) => setGenerateColumnPrompt(e.currentTarget.value)}
+      />
+      <Button
+        size="sm"
+        variant="light"
+        color="grape"
+        fullWidth
+        onClick={handleGenerateColumn}
+        disabled={!enoughRowsForSuggestions}
+        loading={isGenerateColumnLoading}
+      >
+        Add Column
+      </Button>
+    </Stack>
+  );
+
+  const replaceUI = (
+    <Stack>
+      {didGenerateAndReplaceTableError && (
+        <Text size="xs" color="red">
+          Failed to replace rows. Please try again.
+        </Text>
+      )}
+      <Textarea
+        label="Generate data for..."
+        value={generateAndReplacePrompt}
+        onChange={(e) => setGenerateAndReplacePrompt(e.currentTarget.value)}
+      />
+      <NumberInput
+        label="Rows to generate"
+        min={1}
+        max={10}
+        value={generateAndReplaceNumber}
+        onChange={(num) => setGenerateAndReplaceNumber(num || 1)}
+      />
+      <Switch
+        label="Generate diverse outputs"
+        checked={genDiverseOutputs}
+        onChange={(e) => setGenDiverseOutputs(e.currentTarget.checked)}
+      />
+      <Button
+        size="sm"
+        variant="light"
+        color="grape"
+        fullWidth
+        onClick={handleGenerateAndReplaceTable}
+        loading={areValuesLoading}
+      >
+        Replace
+      </Button>
+    </Stack>
+  );
+
+  return (
+    <AIPopover>
+      <Tabs color="grape" defaultValue="replace">
+        <Tabs.List grow>
+          <Tabs.Tab value="replace">Replace</Tabs.Tab>
+          <Tabs.Tab value="extend">Extend</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="extend" pb="xs">
+          {extendUI}
+        </Tabs.Panel>
+        <Tabs.Panel value="replace" pb="xs">
+          {replaceUI}
+        </Tabs.Panel>
+      </Tabs>
+    </AIPopover>
+  );
+}
+
 export interface AIGenReplaceItemsPopoverProps {
   // Strings for the Extend feature to use as a basis.
   values: Dict<string> | string[];
@@ -308,6 +648,7 @@ export function AIGenReplaceItemsPopover({
   const handleGenerateAndReplace = () => {
     setDidGenerateAndReplaceError(false);
     setValuesLoading(true);
+
     generateAndReplace(
       generateAndReplacePrompt,
       generateAndReplaceNumber,
@@ -604,10 +945,10 @@ export function AIGenCodeEvaluatorPopover({
 
     const template = `Edit the code below according to the following: ${editPrompt}
 
-You ${progLang === "javascript" ? "CANNOT import any external packages." : "can use imports if necessary. Do not include any type hints."} 
+You ${progLang === "javascript" ? "CANNOT import any external packages." : "can use imports if necessary. Do not include any type hints."}
 Functions should only return boolean, numeric, or string values. Present the edited code in a single block.
 
-Code: 
+Code:
 \`\`\`${progLang}
 ${currentEvalCode}
 \`\`\``;

--- a/chainforge/react-server/src/AiPopover.tsx
+++ b/chainforge/react-server/src/AiPopover.tsx
@@ -287,7 +287,6 @@ export function AIGenReplaceTablePopover({
   // Generate and Replace state
   const [generateAndReplaceNumber, setGenerateAndReplaceNumber] = useState(5);
   const [generateAndReplacePrompt, setGenerateAndReplacePrompt] = useState("");
-  const [genDiverseOutputs, setGenDiverseOutputs] = useState(false);
   const [didGenerateAndReplaceTableError, setDidGenerateAndReplaceTableError] =
     useState(false);
 
@@ -324,7 +323,6 @@ export function AIGenReplaceTablePopover({
       const generatedTable = await generateAndReplaceTable(
         generateAndReplacePrompt,
         generateAndReplaceNumber,
-        genDiverseOutputs,
         aiFeaturesProvider,
         apiKeys,
       );
@@ -536,11 +534,6 @@ export function AIGenReplaceTablePopover({
         max={50}
         value={generateAndReplaceNumber}
         onChange={(num) => setGenerateAndReplaceNumber(num || 1)}
-      />
-      <Switch
-        label="Generate diverse outputs"
-        checked={genDiverseOutputs}
-        onChange={(e) => setGenDiverseOutputs(e.currentTarget.checked)}
       />
       <Button
         size="sm"

--- a/chainforge/react-server/src/GlobalSettingsModal.tsx
+++ b/chainforge/react-server/src/GlobalSettingsModal.tsx
@@ -518,7 +518,7 @@ const GlobalSettingsModal = forwardRef<GlobalSettingsModalRef, object>(
                   />
                   <Select
                     label="LLM Provider"
-                    description="The LLM provider to use for generative AI features. Currently only supports OpenAI and Bedrock (Anthropic). OpenAI will query gpt-3.5 and gpt-4 models. Bedrock will query Claude-3 models. You must have set the relevant API keys to use the provider."
+                    description="The LLM provider to use for generative AI features. Currently only supports OpenAI and Bedrock (Anthropic). OpenAI will query gpt-4o and gpt-4 models. Bedrock will query Claude-3 models. You must have set the relevant API keys to use the provider."
                     dropdownPosition="bottom"
                     withinPortal
                     defaultValue={getAIFeaturesModelProviders()[0]}

--- a/chainforge/react-server/src/TabularDataNode.tsx
+++ b/chainforge/react-server/src/TabularDataNode.tsx
@@ -24,6 +24,9 @@ import useStore from "./store";
 import { sampleRandomElements } from "./backend/utils";
 import { Dict, TabularDataRowType, TabularDataColType } from "./backend/typing";
 import { Position } from "reactflow";
+import { AIGenReplaceTablePopover } from "./AiPopover";
+import AISuggestionsManager from "./backend/aiSuggestionsManager";
+import { parseTableData } from "./backend/tableUtils";
 
 const defaultRows: TabularDataRowType[] = [
   {
@@ -304,43 +307,8 @@ const TabularDataNode: React.FC<TabularDataNodeProps> = ({ data, id }) => {
   // NOTE: JSON objects should be in row format, with keys
   //       as the header names. The internal keys of the columns will use uids to be unique.
   const importJSONList = (jsonl: unknown) => {
-    if (!Array.isArray(jsonl)) {
-      throw new Error(
-        "Imported tabular data is not in array format: " +
-          (jsonl !== undefined ? (jsonl as object).toString() : ""),
-      );
-    }
-
-    // Extract unique column names
-    const headers = new Set<string>();
-    jsonl.forEach((o) => Object.keys(o).forEach((key) => headers.add(key)));
-
-    // Create new columns with unique ids c0, c1 etc
-    const cols = Array.from(headers).map((h, idx) => ({
-      header: h,
-      key: `c${idx.toString()}`,
-    }));
-
-    // Construct a lookup table from header name to our new key uid
-    const col_key_lookup: Dict<string> = {};
-    cols.forEach((c) => {
-      col_key_lookup[c.header] = c.key;
-    });
-
-    // Construct the table rows by swapping the header names for our new columm keys
-    const rows = jsonl.map((o) => {
-      const row: TabularDataRowType = { __uid: uuidv4() };
-      Object.keys(o).forEach((header) => {
-        const raw_val = o[header];
-        const val =
-          typeof raw_val === "object" ? JSON.stringify(raw_val) : raw_val;
-        row[col_key_lookup[header]] = val.toString();
-      });
-      return row;
-    });
-
-    // Save the new columns and rows
-    setTableColumns(cols);
+    const { columns, rows } = parseTableData(jsonl as any[]);
+    setTableColumns(columns);
     setTableData(rows);
     pingOutputNodes(id);
   };
@@ -499,6 +467,135 @@ const TabularDataNode: React.FC<TabularDataNodeProps> = ({ data, id }) => {
     [ref],
   );
 
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [rowValues, setRowValues] = useState<string[]>(
+    tableData.map((row) => row.value || ""),
+  );
+
+  // Function to add new columns to the right of the existing columns (with optional row values)
+  const addColumns = (
+    newColumns: TabularDataColType[],
+    rowValues?: string[] // If values are passed, they will be used to populate the new columns
+  ) => {
+    setTableColumns((prevColumns) => {
+      // Filter out columns that already exist
+      const filteredNewColumns = newColumns.filter(
+        (col) => !prevColumns.some((existingCol) => existingCol.key === col.key)
+      );
+
+      // If no genuinely new columns, return previous columns
+      if (filteredNewColumns.length === 0) return prevColumns;
+
+      const updatedColumns = [...prevColumns, ...filteredNewColumns];
+
+      setTableData((prevData) => {
+        let updatedRows: TabularDataRowType[] = [];
+
+        if (prevData.length > 0) {
+          // Update the existing rows with the new column values
+          updatedRows = prevData.map((row, rowIndex) => {
+            const updatedRow = { ...row };
+
+            // Set the value for each new column
+            filteredNewColumns.forEach((col) => {
+              // Only set the value if it's not already set
+              if (updatedRow[col.key] === undefined) {
+                updatedRow[col.key] =
+                  rowValues && rowValues[rowIndex] !== undefined
+                    ? rowValues[rowIndex]
+                    : "";
+              }
+            });
+            return updatedRow;
+          });
+        } else if (rowValues && rowValues.length > 0) {
+          // If no rows exist, create rows using rowValues
+          updatedRows = rowValues.map((value) => {
+            const newRow: TabularDataRowType = { __uid: uuidv4() };
+            filteredNewColumns.forEach((col) => {
+              newRow[col.key] = value || "";
+            });
+            return newRow;
+          });
+        } else {
+          // If no rows and no rowValues, create a single blank row
+          const blankRow: TabularDataRowType = { __uid: uuidv4() };
+          filteredNewColumns.forEach((col) => {
+            blankRow[col.key] = "";
+          });
+          updatedRows.push(blankRow);
+        }
+
+        return updatedRows; // Update table rows
+      });
+
+      return updatedColumns; // Update table columns
+    });
+  };
+
+  // Function to add multiple rows to the table
+  const addMultipleRows = (newRows: TabularDataRowType[]) => {
+    setTableData((prev) => {
+      // Remove the last row of the current table data as it is a blank row (if table is not empty)
+      const newTableData = prev.length > 0 ? prev.slice(0, -1) : [];
+
+      // Add the new rows to the table
+      const addedRows = newRows.map((value) => {
+        const newRow: TabularDataRowType = { __uid: uuidv4() };
+
+        // Map to correct column keys
+        tableColumns.forEach((col, index) => {
+          newRow[col.key] = value[`col-${index}`] || ""; // If (false, empty, null, etc...), default to empty string
+        });
+
+        return newRow;
+      });
+
+      // Return the updated table data with the new rows
+      return [...newTableData, ...addedRows];
+    });
+  };
+
+  // Function to replace the entire table (columns and rows)
+  const replaceTable = (
+    columns: TabularDataColType[],
+    rows: TabularDataRowType[],
+  ) => {
+    // Validate columns
+    if (!Array.isArray(columns) || columns.length === 0) {
+      console.error("Invalid columns provided for table replacement.");
+      return;
+    }
+
+    // Validate rows
+    if (!Array.isArray(rows)) {
+      console.error("Invalid rows provided for table replacement.");
+      return;
+    }
+
+    // Replace columns
+    const updatedColumns = columns.map((col, idx) => ({
+      header: col.header,
+      key: col.key || `c${idx}`, // Ensure each column has a uid
+    }));
+
+    // Replace rows
+    const updatedRows = rows.map((row) => {
+      const newRow: TabularDataRowType = { __uid: uuidv4() };
+
+      updatedColumns.forEach((column) => {
+        // Map row data to columns, default to empty strings for missing values
+        newRow[column.key] = row[column.key] || "";
+      });
+      return newRow;
+    });
+
+    setTableColumns(updatedColumns); // Replace table columns
+    setTableData(updatedRows); // Replace table rows
+    setRowValues(updatedRows.map((row) => JSON.stringify(row))); // Update row values
+  };
+
   return (
     <BaseNode
       classNames="tabular-data-node"
@@ -511,6 +608,15 @@ const TabularDataNode: React.FC<TabularDataNodeProps> = ({ data, id }) => {
         nodeId={id}
         icon={"🗂️"}
         customButtons={[
+          <AIGenReplaceTablePopover
+            key="ai-popover"
+            values={tableData}
+            onAddRows={addMultipleRows}
+            onAddColumns={addColumns}
+            onReplaceTable={replaceTable}
+            areValuesLoading={isLoading}
+            setValuesLoading={setIsLoading}
+          />,
           <Tooltip
             key={0}
             label="Accepts xlsx, jsonl, and csv files with a header row"
@@ -525,7 +631,6 @@ const TabularDataNode: React.FC<TabularDataNodeProps> = ({ data, id }) => {
           </Tooltip>,
         ]}
       />
-
       <RenameValueModal
         ref={renameColumnModal}
         initialValue={

--- a/chainforge/react-server/src/TabularDataNode.tsx
+++ b/chainforge/react-server/src/TabularDataNode.tsx
@@ -25,7 +25,6 @@ import { sampleRandomElements } from "./backend/utils";
 import { Dict, TabularDataRowType, TabularDataColType } from "./backend/typing";
 import { Position } from "reactflow";
 import { AIGenReplaceTablePopover } from "./AiPopover";
-import AISuggestionsManager from "./backend/aiSuggestionsManager";
 import { parseTableData } from "./backend/tableUtils";
 
 const defaultRows: TabularDataRowType[] = [
@@ -476,12 +475,13 @@ const TabularDataNode: React.FC<TabularDataNodeProps> = ({ data, id }) => {
   // Function to add new columns to the right of the existing columns (with optional row values)
   const addColumns = (
     newColumns: TabularDataColType[],
-    rowValues?: string[] // If values are passed, they will be used to populate the new columns
+    rowValues?: string[], // If values are passed, they will be used to populate the new columns
   ) => {
     setTableColumns((prevColumns) => {
       // Filter out columns that already exist
       const filteredNewColumns = newColumns.filter(
-        (col) => !prevColumns.some((existingCol) => existingCol.key === col.key)
+        (col) =>
+          !prevColumns.some((existingCol) => existingCol.key === col.key),
       );
 
       // If no genuinely new columns, return previous columns
@@ -538,7 +538,12 @@ const TabularDataNode: React.FC<TabularDataNodeProps> = ({ data, id }) => {
   const addMultipleRows = (newRows: TabularDataRowType[]) => {
     setTableData((prev) => {
       // Remove the last row of the current table data as it is a blank row (if table is not empty)
-      const newTableData = prev.length > 0 ? prev.slice(0, -1) : [];
+      let newTableData = prev;
+      if (prev.length > 0) {
+        const lastRow = prev[prev.length - 1]; // Get the last row
+        const emptyLastRow = Object.values(lastRow).every((val) => !val); // Check if the last row is empty
+        if (emptyLastRow) newTableData = prev.slice(0, -1); // Remove the last row if it is empty
+      }
 
       // Add the new rows to the table
       const addedRows = newRows.map((value) => {
@@ -611,6 +616,7 @@ const TabularDataNode: React.FC<TabularDataNodeProps> = ({ data, id }) => {
           <AIGenReplaceTablePopover
             key="ai-popover"
             values={tableData}
+            colValues={tableColumns}
             onAddRows={addMultipleRows}
             onAddColumns={addColumns}
             onReplaceTable={replaceTable}

--- a/chainforge/react-server/src/backend/ai.ts
+++ b/chainforge/react-server/src/backend/ai.ts
@@ -148,12 +148,8 @@ function GARSystemMessage(
  * @param generatePrompts whether the output should be commands
  * @returns the system message
  */
-function GARTSystemMessage(
-  n: number,
-  creative?: boolean,
-  generatePrompts?: boolean,
-): string {
-  return `Generate a table with exactly ${n} rows. Format your response as a markdown table using. Do not ever repeat anything.${creative ? "Be unconventional with your outputs." : ""} ${generatePrompts ? "Your outputs should be commands that can be given to an AI chat assistant." : ""} If the user has specified items or inputs to their command, generate a template in Jinja format, with single braces {} around the masked variables.`;
+function GARTSystemMessage(n: number, generatePrompts?: boolean): string {
+  return `Generate a table with exactly ${n} rows. Format your response as a markdown table using. Do not ever repeat anything. ${generatePrompts ? "Your outputs should be commands that can be given to an AI chat assistant." : ""} If the user has specified items or inputs to their command, generate a template in Jinja format, with single braces {} around the masked variables.`;
 }
 
 /**
@@ -587,7 +583,6 @@ export async function generateAndReplace(
  * Uses an LLM to generate a table with `n` rows based on the pattern explained in `prompt`.
  * @param prompt Description or pattern for the table content.
  * @param n Number of rows to generate.
- * @param creative Whether the output should be creative or conventional.
  * @param provider The LLM provider to use.
  * @param apiKeys API keys required for the LLM query.
  * @returns A promise resolving to an object containing the columns and rows of the generated table.
@@ -595,7 +590,6 @@ export async function generateAndReplace(
 export async function generateAndReplaceTable(
   prompt: string,
   n: number,
-  creative: boolean,
   provider: string,
   apiKeys: Dict,
 ): Promise<{ cols: string[]; rows: Row[] }> {
@@ -610,7 +604,7 @@ export async function generateAndReplaceTable(
       messages: [
         {
           role: "system",
-          content: GARTSystemMessage(n, creative, generatePrompts),
+          content: GARTSystemMessage(n, generatePrompts),
         },
       ],
       fill_history: {},

--- a/chainforge/react-server/src/backend/tableUtils.ts
+++ b/chainforge/react-server/src/backend/tableUtils.ts
@@ -8,7 +8,6 @@ export function parseTableData(rawTableData: any[]): {
   columns: TabularDataColType[];
   rows: TabularDataRowType[];
 } {
-
   if (!Array.isArray(rawTableData)) {
     throw new Error(
       "Table data is not in array format: " +

--- a/chainforge/react-server/src/backend/tableUtils.ts
+++ b/chainforge/react-server/src/backend/tableUtils.ts
@@ -1,0 +1,52 @@
+import { v4 as uuidv4 } from "uuid";
+import { Dict, TabularDataRowType, TabularDataColType } from "./typing";
+/*
+  This file contains utility functions for parsing raw table data
+  into a format for TabularDataNode
+*/
+export function parseTableData(rawTableData: any[]): {
+  columns: TabularDataColType[];
+  rows: TabularDataRowType[];
+} {
+
+  if (!Array.isArray(rawTableData)) {
+    throw new Error(
+      "Table data is not in array format: " +
+        (rawTableData !== undefined && rawTableData !== null
+          ? String(rawTableData)
+          : ""),
+    );
+  }
+
+  // Extract unique column names
+  const headers = new Set<string>();
+  rawTableData.forEach((row) =>
+    Object.keys(row).forEach((key) => headers.add(key)),
+  );
+
+  // Create columns with unique IDs
+  const columns = Array.from(headers).map((header, idx) => ({
+    header,
+    key: `c${idx}`,
+  }));
+
+  // Create a lookup table for column keys
+  const columnKeyLookup: Dict<string> = {};
+  columns.forEach((col) => {
+    columnKeyLookup[col.header] = col.key;
+  });
+
+  // Map rows to the new column keys
+  const rows = rawTableData.map((row) => {
+    const parsedRow: TabularDataRowType = { __uid: uuidv4() };
+    Object.keys(row).forEach((header) => {
+      const rawValue = row[header];
+      const value =
+        typeof rawValue === "object" ? JSON.stringify(rawValue) : rawValue;
+      parsedRow[columnKeyLookup[header]] = value?.toString() ?? "";
+    });
+    return parsedRow;
+  });
+
+  return { columns, rows };
+}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="chainforge",
-    version="0.3.2.4",
+    version="0.3.2.5",
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION
Adds the purple sparkly button functionality to the Tabular Data Node:
- "Replace" generates a table from scratch
- "Extend" has two options: 
    - Add Rows
    - Add a Column

Both will work over medium-sized (~100-1000 rows) datasets. 
However, note that Add a Column will take a long time for larger datasets. 

<img width="1020" alt="Screen Shot 2024-12-19 at 3 35 38 PM" src="https://github.com/user-attachments/assets/2b214b9c-b6aa-4773-a0a0-30b3844428a7" />

Authored by @Kraft-Cheese