### PR TITLE
Allow users to enter custom model names to all providers

### DIFF
--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -2512,8 +2512,8 @@ export const ModelSettings: Dict<ModelSettingsDict> = {
   deepseek: DeepSeekSettings,
 };
 
-// A lookup that converts the base_model names into LLMProviders. 
-// Used for backwards compatibility. 
+// A lookup that converts the base_model names into LLMProviders.
+// Used for backwards compatibility.
 // TODO in future: Deprecate base_model and migrate fully to using LLMProvider type throughout.
 export function baseModelToProvider(base_model: string): LLMProvider {
   const lookup: Record<string, LLMProvider> = {
@@ -2539,7 +2539,7 @@ export function baseModelToProvider(base_model: string): LLMProvider {
     deepseek: LLMProvider.DeepSeek,
   };
   return lookup[base_model] ?? LLMProvider.Custom;
-};
+}
 
 export function getSettingsSchemaForLLM(
   llm_name: string,

--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -82,8 +82,16 @@ const ChatGPTSettings: ModelSettingsDict = {
           "text-davinci-003",
           "text-davinci-002",
           "code-davinci-002",
+          "Other (OpenAI)",
         ],
         default: "gpt-3.5-turbo",
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       system_msg: {
         type: "string",
@@ -198,6 +206,7 @@ const ChatGPTSettings: ModelSettingsDict = {
     },
     model: {
       "ui:help": "Defaults to gpt-3.5-turbo.",
+      "ui:widget": "datalist",
     },
     system_msg: {
       "ui:widget": "textarea",
@@ -344,8 +353,15 @@ const DeepSeekSettings: ModelSettingsDict = {
         title: "Model Version",
         description:
           "Select a DeepSeek model to query. For more details on the differences, see the DeepSeek API documentation.",
-        enum: ["deepseek-chat", "deepseek-reasoner"],
+        enum: ["deepseek-chat", "deepseek-reasoner", "Other (DeepSeek)"],
         default: "deepseek-chat",
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       system_msg: {
         type: "string",
@@ -435,6 +451,7 @@ const DeepSeekSettings: ModelSettingsDict = {
     ...ChatGPTSettings.uiSchema,
     model: {
       "ui:help": "Defaults to deepseek-chat.",
+      "ui:widget": "datalist",
     },
   },
   postprocessors: ChatGPTSettings.postprocessors,
@@ -458,8 +475,15 @@ const DalleSettings: ModelSettingsDict = {
         title: "Model Version",
         description:
           "Select an OpenAI image model to query. For more details on the differences, see the OpenAI API documentation.",
-        enum: ["dall-e-3", "dall-e-2"],
+        enum: ["dall-e-3", "dall-e-2", "Other (OpenAI)"],
         default: "dall-e-2",
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       size: {
         type: "string",
@@ -553,6 +577,7 @@ const ClaudeSettings: ModelSettingsDict = {
           "claude-instant-v1.1",
           "claude-instant-v1.1-100k",
           "claude-instant-v1.0",
+          "Other (Anthropic)",
         ],
         default: "claude-3-5-sonnet-latest",
         shortname_map: {
@@ -564,6 +589,13 @@ const ClaudeSettings: ModelSettingsDict = {
           "claude-3-haiku-20240307": "claude-3-haiku",
           "claude-3-5-haiku-latest": "claude-3.5-haiku",
         },
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       system_msg: {
         type: "string",
@@ -745,6 +777,7 @@ const PaLM2Settings: ModelSettingsDict = {
           "gemini-pro",
           "text-bison-001",
           "chat-bison-001",
+          "Other (Google)",
         ],
         default: "gemini-1.5-flash",
         shortname_map: {
@@ -756,6 +789,13 @@ const PaLM2Settings: ModelSettingsDict = {
           "gemini-1.5-flash": "Gemini Flash",
           "gemini-1.5-flash-8b": "Gemini Flash 8B",
         },
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       system_msg: {
         type: "string",
@@ -1248,6 +1288,7 @@ const AlephAlphaLuminousSettings: ModelSettingsDict = {
           "luminous-base",
           "luminous-supreme",
           "luminous-supreme-control",
+          "Other (AlephAlpha)",
         ],
         default: "luminous-base",
         shortname_map: {
@@ -1258,6 +1299,13 @@ const AlephAlphaLuminousSettings: ModelSettingsDict = {
           "luminous-supreme": "luminous-supr",
           "luminous-supreme-control": "luminous-supr-ctrl",
         },
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       temperature: {
         type: "number",
@@ -1605,12 +1653,20 @@ const BedrockClaudeSettings: ModelSettingsDict = {
           NativeLLM.Bedrock_Claude_Instant_1,
           NativeLLM.Bedrock_Claude_2,
           NativeLLM.Bedrock_Claude_2_1,
+          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Claude_3_Haiku,
         shortname_map: {
           "anthropic.claude-3-sonnet-20240229-v1:0": "claude-3-sonnet",
           "anthropic.claude-3-haiku-20240307-v1:0": "claude-3-haiku",
         },
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       system_msg: {
         type: "string",
@@ -1738,8 +1794,16 @@ const BedrockJurassic2Settings: ModelSettingsDict = {
         enum: [
           NativeLLM.Bedrock_Jurassic_Mid,
           NativeLLM.Bedrock_Jurassic_Ultra,
+          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Jurassic_Ultra,
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       temperature: {
         type: "number",
@@ -1862,8 +1926,16 @@ const BedrockTitanSettings: ModelSettingsDict = {
           NativeLLM.Bedrock_Titan_Large,
           NativeLLM.Bedrock_Titan_Light,
           NativeLLM.Bedrock_Titan_Express,
+          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Titan_Large,
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       temperature: {
         type: "number",
@@ -1956,8 +2028,16 @@ const BedrockCommandTextSettings: ModelSettingsDict = {
         enum: [
           NativeLLM.Bedrock_Command_Text,
           NativeLLM.Bedrock_Command_Text_Light,
+          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Command_Text,
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       temperature: {
         type: "number",
@@ -2072,8 +2152,16 @@ const MistralSettings: ModelSettingsDict = {
         enum: [
           NativeLLM.Bedrock_Mistral_Mistral,
           NativeLLM.Bedrock_Mistral_Mistral_Large,
+          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Mistral_Mistral,
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       temperature: {
         type: "number",
@@ -2205,8 +2293,16 @@ const BedrockLlama2ChatSettings: ModelSettingsDict = {
         enum: [
           NativeLLM.Bedrock_Meta_LLama2Chat_13b,
           NativeLLM.Bedrock_Meta_LLama2Chat_70b,
+          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Meta_LLama2Chat_13b,
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       temperature: {
         type: "number",
@@ -2378,8 +2474,16 @@ export const TogetherChatSettings: ModelSettingsDict = {
           "Undi95/Toppy-M-7B",
           "WizardLM/WizardLM-13B-V1.2",
           "upstage/SOLAR-10.7B-Instruct-v1.0",
+          "Other (Together)",
         ],
         default: "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+      },
+      custom_model: {
+        type: "string",
+        title: "Other model version",
+        description:
+          "(Only used if you select 'Other' above.) Enter the name of the model you wish to query, in case it is not in the list above.",
+        default: "",
       },
       temperature: {
         type: "number",

--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -82,16 +82,8 @@ const ChatGPTSettings: ModelSettingsDict = {
           "text-davinci-003",
           "text-davinci-002",
           "code-davinci-002",
-          "Other (OpenAI)",
         ],
         default: "gpt-3.5-turbo",
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       system_msg: {
         type: "string",
@@ -164,11 +156,11 @@ const ChatGPTSettings: ModelSettingsDict = {
           "If specified, the OpenAI API will make a best effort to sample deterministically, such that repeated requests with the same seed and parameters should return the same result. Determinism is not guaranteed.",
         allow_empty_str: true,
       },
-      max_tokens: {
+      max_completion_tokens: {
         type: "integer",
-        title: "max_tokens",
+        title: "max_completion_tokens",
         description:
-          "The maximum number of tokens to generate in the chat completion. (The total length of input tokens and generated tokens is limited by the model's context length.)",
+          "An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.",
       },
       presence_penalty: {
         type: "number",
@@ -252,7 +244,7 @@ const ChatGPTSettings: ModelSettingsDict = {
       "ui:widget": "textarea",
       "ui:help": "Defaults to empty.",
     },
-    max_tokens: {
+    max_completion_tokens: {
       "ui:help": "Defaults to infinity.",
     },
     seed: {
@@ -353,15 +345,8 @@ const DeepSeekSettings: ModelSettingsDict = {
         title: "Model Version",
         description:
           "Select a DeepSeek model to query. For more details on the differences, see the DeepSeek API documentation.",
-        enum: ["deepseek-chat", "deepseek-reasoner", "Other (DeepSeek)"],
+        enum: ["deepseek-chat", "deepseek-reasoner"],
         default: "deepseek-chat",
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       system_msg: {
         type: "string",
@@ -475,15 +460,8 @@ const DalleSettings: ModelSettingsDict = {
         title: "Model Version",
         description:
           "Select an OpenAI image model to query. For more details on the differences, see the OpenAI API documentation.",
-        enum: ["dall-e-3", "dall-e-2", "Other (OpenAI)"],
+        enum: ["dall-e-3", "dall-e-2"],
         default: "dall-e-2",
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       size: {
         type: "string",
@@ -519,6 +497,7 @@ const DalleSettings: ModelSettingsDict = {
     },
     model: {
       "ui:help": "Defaults to dalle-2.",
+      "ui:widget": "datalist",
     },
     size: {
       "ui:help": "Defaults to 256x256.",
@@ -577,7 +556,6 @@ const ClaudeSettings: ModelSettingsDict = {
           "claude-instant-v1.1",
           "claude-instant-v1.1-100k",
           "claude-instant-v1.0",
-          "Other (Anthropic)",
         ],
         default: "claude-3-5-sonnet-latest",
         shortname_map: {
@@ -589,13 +567,6 @@ const ClaudeSettings: ModelSettingsDict = {
           "claude-3-haiku-20240307": "claude-3-haiku",
           "claude-3-5-haiku-latest": "claude-3.5-haiku",
         },
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       system_msg: {
         type: "string",
@@ -688,6 +659,7 @@ const ClaudeSettings: ModelSettingsDict = {
     model: {
       "ui:help":
         "Defaults to claude-2.1. Note that Anthropic models are subject to change. Model names prior to Claude 2, including 100k context window, are no longer listed on the Anthropic site, so they may or may not work.",
+      "ui:widget": "datalist",
     },
     system_msg: {
       "ui:widget": "textarea",
@@ -777,7 +749,6 @@ const PaLM2Settings: ModelSettingsDict = {
           "gemini-pro",
           "text-bison-001",
           "chat-bison-001",
-          "Other (Google)",
         ],
         default: "gemini-1.5-flash",
         shortname_map: {
@@ -789,13 +760,6 @@ const PaLM2Settings: ModelSettingsDict = {
           "gemini-1.5-flash": "Gemini Flash",
           "gemini-1.5-flash-8b": "Gemini Flash 8B",
         },
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       system_msg: {
         type: "string",
@@ -857,6 +821,7 @@ const PaLM2Settings: ModelSettingsDict = {
     },
     model: {
       "ui:help": "Defaults to gemini-pro.",
+      "ui:widget": "datalist",
     },
     system_msg: {
       "ui:widget": "textarea",
@@ -1007,6 +972,7 @@ const DalaiModelSettings: ModelSettingsDict = {
     model: {
       "ui:help":
         "NOTE: You must have installed the selected model and have Dalai be running and accessible on the local environment with which you are running the ChainForge server.",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 0.5.",
@@ -1132,13 +1098,6 @@ const HuggingFaceTextInferenceSettings: ModelSettingsDict = {
           "bigcode/starcoder": "starcoder",
         },
       },
-      custom_model: {
-        type: "string",
-        title: "Custom HF model endpoint",
-        description:
-          "(Only used if you select 'Other' above.) Enter the HuggingFace id of the text generation model you wish to query via the inference API. Alternatively, if you have hosted a model on HF Inference Endpoints, you can enter the full URL of the endpoint here.",
-        default: "",
-      },
       model_type: {
         type: "string",
         title: "Model Type (Text or Chat)",
@@ -1228,6 +1187,7 @@ const HuggingFaceTextInferenceSettings: ModelSettingsDict = {
     },
     model: {
       "ui:help": "Defaults to Falcon.7B.",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 1.0.",
@@ -1288,7 +1248,6 @@ const AlephAlphaLuminousSettings: ModelSettingsDict = {
           "luminous-base",
           "luminous-supreme",
           "luminous-supreme-control",
-          "Other (AlephAlpha)",
         ],
         default: "luminous-base",
         shortname_map: {
@@ -1299,13 +1258,6 @@ const AlephAlphaLuminousSettings: ModelSettingsDict = {
           "luminous-supreme": "luminous-supr",
           "luminous-supreme-control": "luminous-supr-ctrl",
         },
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       temperature: {
         type: "number",
@@ -1378,6 +1330,7 @@ const AlephAlphaLuminousSettings: ModelSettingsDict = {
     },
     model: {
       "ui:help": "Defaults to Luminous Base.",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 0.0.",
@@ -1653,20 +1606,12 @@ const BedrockClaudeSettings: ModelSettingsDict = {
           NativeLLM.Bedrock_Claude_Instant_1,
           NativeLLM.Bedrock_Claude_2,
           NativeLLM.Bedrock_Claude_2_1,
-          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Claude_3_Haiku,
         shortname_map: {
           "anthropic.claude-3-sonnet-20240229-v1:0": "claude-3-sonnet",
           "anthropic.claude-3-haiku-20240307-v1:0": "claude-3-haiku",
         },
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       system_msg: {
         type: "string",
@@ -1738,6 +1683,7 @@ const BedrockClaudeSettings: ModelSettingsDict = {
     model: {
       "ui:help":
         "Defaults to claude-2. Note that Anthropic models in particular are subject to change. Model names prior to Claude 2, including 100k context window, are no longer listed on the Anthropic site, so they may or may not work.",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 1.0.",
@@ -1794,16 +1740,8 @@ const BedrockJurassic2Settings: ModelSettingsDict = {
         enum: [
           NativeLLM.Bedrock_Jurassic_Mid,
           NativeLLM.Bedrock_Jurassic_Ultra,
-          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Jurassic_Ultra,
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       temperature: {
         type: "number",
@@ -1879,7 +1817,8 @@ const BedrockJurassic2Settings: ModelSettingsDict = {
       "ui:autofocus": true,
     },
     model: {
-      "ui:help": "Defaults to Jurassic 2 Ultra. ",
+      "ui:help": "Defaults to Jurassic 2 Ultra.",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 1.0.",
@@ -1926,16 +1865,8 @@ const BedrockTitanSettings: ModelSettingsDict = {
           NativeLLM.Bedrock_Titan_Large,
           NativeLLM.Bedrock_Titan_Light,
           NativeLLM.Bedrock_Titan_Express,
-          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Titan_Large,
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       temperature: {
         type: "number",
@@ -1989,6 +1920,7 @@ const BedrockTitanSettings: ModelSettingsDict = {
     },
     model: {
       "ui:help": "Defaults to Titan Large",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 1.0.",
@@ -2028,16 +1960,8 @@ const BedrockCommandTextSettings: ModelSettingsDict = {
         enum: [
           NativeLLM.Bedrock_Command_Text,
           NativeLLM.Bedrock_Command_Text_Light,
-          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Command_Text,
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       temperature: {
         type: "number",
@@ -2107,6 +2031,7 @@ const BedrockCommandTextSettings: ModelSettingsDict = {
     },
     model: {
       "ui:help": "Defaults to Command Text",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 1.0.",
@@ -2152,16 +2077,8 @@ const MistralSettings: ModelSettingsDict = {
         enum: [
           NativeLLM.Bedrock_Mistral_Mistral,
           NativeLLM.Bedrock_Mistral_Mistral_Large,
-          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Mistral_Mistral,
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       temperature: {
         type: "number",
@@ -2224,6 +2141,7 @@ const MistralSettings: ModelSettingsDict = {
     },
     model: {
       "ui:help": "Defaults to Mistral",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 1.0.",
@@ -2293,16 +2211,8 @@ const BedrockLlama2ChatSettings: ModelSettingsDict = {
         enum: [
           NativeLLM.Bedrock_Meta_LLama2Chat_13b,
           NativeLLM.Bedrock_Meta_LLama2Chat_70b,
-          "Other (Bedrock)",
         ],
         default: NativeLLM.Bedrock_Meta_LLama2Chat_13b,
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' in the model list above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       temperature: {
         type: "number",
@@ -2350,6 +2260,7 @@ const BedrockLlama2ChatSettings: ModelSettingsDict = {
     },
     model: {
       "ui:help": "Defaults to LlamaChat 13B",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 1.0.",
@@ -2474,16 +2385,8 @@ export const TogetherChatSettings: ModelSettingsDict = {
           "Undi95/Toppy-M-7B",
           "WizardLM/WizardLM-13B-V1.2",
           "upstage/SOLAR-10.7B-Instruct-v1.0",
-          "Other (Together)",
         ],
         default: "meta-llama/Llama-3.3-70B-Instruct-Turbo",
-      },
-      custom_model: {
-        type: "string",
-        title: "Other model version",
-        description:
-          "(Only used if you select 'Other' above.) Enter the name of the model you wish to query, in case it is not in the list above.",
-        default: "",
       },
       temperature: {
         type: "number",
@@ -2530,7 +2433,8 @@ export const TogetherChatSettings: ModelSettingsDict = {
       "ui:autofocus": true,
     },
     model: {
-      "ui:help": "Defaults to LlamaChat 13B",
+      "ui:help": "Defaults to Llama-3.3-70B",
+      "ui:widget": "datalist",
     },
     temperature: {
       "ui:help": "Defaults to 1.0.",
@@ -2606,6 +2510,35 @@ export const ModelSettings: Dict<ModelSettingsDict> = {
   "br.meta.llama3": BedrockLlama3Settings,
   together: TogetherChatSettings,
   deepseek: DeepSeekSettings,
+};
+
+// A lookup that converts the base_model names into LLMProviders. 
+// Used for backwards compatibility. 
+// TODO in future: Deprecate base_model and migrate fully to using LLMProvider type throughout.
+export function baseModelToProvider(base_model: string): LLMProvider {
+  const lookup: Record<string, LLMProvider> = {
+    "gpt-3.5-turbo": LLMProvider.OpenAI,
+    "gpt-4": LLMProvider.OpenAI,
+    "dall-e": LLMProvider.OpenAI,
+    "claude-v1": LLMProvider.Anthropic,
+    "palm2-bison": LLMProvider.Google,
+    dalai: LLMProvider.Dalai,
+    "azure-openai": LLMProvider.Azure_OpenAI,
+    hf: LLMProvider.HuggingFace,
+    "luminous-base": LLMProvider.Aleph_Alpha,
+    ollama: LLMProvider.Ollama,
+    "br.anthropic.claude": LLMProvider.Bedrock,
+    "br.ai21.j2": LLMProvider.Bedrock,
+    "br.amazon.titan": LLMProvider.Bedrock,
+    "br.cohere.command": LLMProvider.Bedrock,
+    "br.mistral.mistral": LLMProvider.Bedrock,
+    "br.mistral.mixtral": LLMProvider.Bedrock,
+    "br.meta.llama2": LLMProvider.Bedrock,
+    "br.meta.llama3": LLMProvider.Bedrock,
+    together: LLMProvider.Together,
+    deepseek: LLMProvider.DeepSeek,
+  };
+  return lookup[base_model] ?? LLMProvider.Custom;
 };
 
 export function getSettingsSchemaForLLM(

--- a/chainforge/react-server/src/ModelSettingsModal.tsx
+++ b/chainforge/react-server/src/ModelSettingsModal.tsx
@@ -14,7 +14,6 @@ import Picker from "@emoji-mart/react";
 import validator from "@rjsf/validator-ajv8";
 import Form from "@rjsf/core";
 import { WidgetProps } from "@rjsf/utils";
-import { v4 as uuid } from "uuid";
 import {
   ModelSettings,
   getDefaultModelFormData,
@@ -27,13 +26,8 @@ import {
   ModelSettingsDict,
 } from "./backend/typing";
 
-// const string_exists = (s: any): boolean => {
-//   return s !== undefined && typeof s === "string" && s.trim().length > 0;
-// };
-
 // Custom UI widgets for react-jsonschema-form
 const DatalistWidget = (props: WidgetProps) => {
-  console.log("DatalistWidget props:", props, props.value);
   const [data, setData] = useState(
     (
       props.options.enumOptions?.map((option, index) => ({
@@ -66,24 +60,6 @@ const DatalistWidget = (props: WidgetProps) => {
       }}
     />
   );
-
-  // This works but when the list gets long there's a rendering error on Chrome.
-  // const listId = 'datalist-' + uuid();
-  // return (
-  //   <div>
-  //     <input
-  //       type="text"
-  //       list={listId}
-  //       value={props.value || ''}
-  //       onChange={(event) => props.onChange(event.target.value)}
-  //     />
-  //     <datalist id={listId}>
-  //       {props.options.enumOptions?.map((option, index) => (
-  //         <option key={index} value={option.value} />
-  //       ))}
-  //     </datalist>
-  //   </div>
-  // );
 };
 
 const widgets = {

--- a/chainforge/react-server/src/ModelSettingsModal.tsx
+++ b/chainforge/react-server/src/ModelSettingsModal.tsx
@@ -35,10 +35,16 @@ import {
 const DatalistWidget = (props: WidgetProps) => {
   console.log("DatalistWidget props:", props, props.value);
   const [data, setData] = useState(
-    (props.options.enumOptions?.map((option, index) => ({
-      value: option.value,
-      label: option.value,
-    })) ?? []).concat(props.options.enumOptions?.find((o) => o.value === props.value) ? [] : { value: props.value, label: props.value }),
+    (
+      props.options.enumOptions?.map((option, index) => ({
+        value: option.value,
+        label: option.value,
+      })) ?? []
+    ).concat(
+      props.options.enumOptions?.find((o) => o.value === props.value)
+        ? []
+        : { value: props.value, label: props.value },
+    ),
   );
 
   return (
@@ -61,7 +67,7 @@ const DatalistWidget = (props: WidgetProps) => {
     />
   );
 
-  // This works but when the list gets long there's a rendering error on Chrome. 
+  // This works but when the list gets long there's a rendering error on Chrome.
   // const listId = 'datalist-' + uuid();
   // return (
   //   <div>
@@ -221,10 +227,7 @@ const ModelSettingsModal = forwardRef<
       // In this case, we auto-change the shortname, to save user's time and nickname models appropriately.
       const modelname = state.formData.model as string | undefined;
       const shortname = state.formData.shortname as string | undefined;
-      if (
-        shortname === initShortname &&
-        modelname !== initModelName
-      ) {
+      if (shortname === initShortname && modelname !== initModelName) {
         // Only change the shortname if there is a distinct model name.
         // If not, let the shortname remain the same for this time, and just remember the model name.
         if (initModelName !== undefined) {

--- a/chainforge/react-server/src/ModelSettingsModal.tsx
+++ b/chainforge/react-server/src/ModelSettingsModal.tsx
@@ -4,14 +4,17 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useEffect,
+  useMemo,
 } from "react";
-import { Button, Modal, Popover } from "@mantine/core";
+import { Button, Modal, Popover, Select } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import emojidata from "@emoji-mart/data";
 import Picker from "@emoji-mart/react";
 // react-jsonschema-form
 import validator from "@rjsf/validator-ajv8";
 import Form from "@rjsf/core";
+import { WidgetProps } from "@rjsf/utils";
+import { v4 as uuid } from "uuid";
 import {
   ModelSettings,
   getDefaultModelFormData,
@@ -23,6 +26,63 @@ import {
   LLMSpec,
   ModelSettingsDict,
 } from "./backend/typing";
+
+// const string_exists = (s: any): boolean => {
+//   return s !== undefined && typeof s === "string" && s.trim().length > 0;
+// };
+
+// Custom UI widgets for react-jsonschema-form
+const DatalistWidget = (props: WidgetProps) => {
+  console.log("DatalistWidget props:", props, props.value);
+  const [data, setData] = useState(
+    (props.options.enumOptions?.map((option, index) => ({
+      value: option.value,
+      label: option.value,
+    })) ?? []).concat(props.options.enumOptions?.find((o) => o.value === props.value) ? [] : { value: props.value, label: props.value }),
+  );
+
+  return (
+    <Select
+      data={data}
+      defaultValue={props.value ?? ""}
+      onChange={(newVal) => props.onChange(newVal ?? "")}
+      size="sm"
+      placeholder="Select items"
+      nothingFound="Nothing found"
+      searchable
+      creatable
+      getCreateLabel={(query) => `+ Create ${query}`}
+      onCreate={(query) => {
+        const item = { value: query, label: query };
+        setData((current) => [...current, item]);
+        console.log(item);
+        return item;
+      }}
+    />
+  );
+
+  // This works but when the list gets long there's a rendering error on Chrome. 
+  // const listId = 'datalist-' + uuid();
+  // return (
+  //   <div>
+  //     <input
+  //       type="text"
+  //       list={listId}
+  //       value={props.value || ''}
+  //       onChange={(event) => props.onChange(event.target.value)}
+  //     />
+  //     <datalist id={listId}>
+  //       {props.options.enumOptions?.map((option, index) => (
+  //         <option key={index} value={option.value} />
+  //       ))}
+  //     </datalist>
+  //   </div>
+  // );
+};
+
+const widgets = {
+  datalist: DatalistWidget,
+};
 
 export interface ModelSettingsModalRef {
   trigger: () => void;
@@ -84,9 +144,16 @@ const ModelSettingsModal = forwardRef<
       setSchema(schema);
       setUISchema(settingsSpec.uiSchema);
       setBaseModelName(settingsSpec.fullName);
+
+      // If the user has already saved custom settings...
       if (model.formData) {
         setFormData(model.formData);
         setInitShortname(model.formData.shortname as string | undefined);
+
+        // If the "custom_model" field is set, use that as the initial model name, overriding "model".
+        // if (string_exists(model.formData.custom_model))
+        // setInitModelName(model.formData.custom_model as string);
+        // else
         setInitModelName(model.formData.model as string | undefined);
       } else {
         // Create settings from schema
@@ -154,7 +221,10 @@ const ModelSettingsModal = forwardRef<
       // In this case, we auto-change the shortname, to save user's time and nickname models appropriately.
       const modelname = state.formData.model as string | undefined;
       const shortname = state.formData.shortname as string | undefined;
-      if (shortname === initShortname && modelname !== initModelName) {
+      if (
+        shortname === initShortname &&
+        modelname !== initModelName
+      ) {
         // Only change the shortname if there is a distinct model name.
         // If not, let the shortname remain the same for this time, and just remember the model name.
         if (initModelName !== undefined) {
@@ -244,8 +314,9 @@ const ModelSettingsModal = forwardRef<
       <Form
         schema={schema}
         uiSchema={uiSchema}
+        widgets={widgets} // Custom UI widgets
         formData={formData}
-        // @ts-expect-error This is literally the example code from react-json-schema; no idea why it wouldn't typecheck correctly.
+        // // @ts-expect-error This is literally the example code from react-json-schema; no idea why it wouldn't typecheck correctly.
         validator={validator}
         // @ts-expect-error Expect format is LLMSpec.
         onChange={onFormDataChange}

--- a/chainforge/react-server/src/backend/__test__/query.test.ts
+++ b/chainforge/react-server/src/backend/__test__/query.test.ts
@@ -2,11 +2,11 @@
  * @jest-environment node
  */
 import { PromptPipeline } from "../query";
-import { LLM, NativeLLM } from "../models";
+import { LLM, LLMProvider, NativeLLM } from "../models";
 import { expect, test } from "@jest/globals";
 import { LLMResponseError, RawLLMResponseObject } from "../typing";
 
-async function prompt_model(model: LLM): Promise<void> {
+async function prompt_model(model: LLM, provider: LLMProvider): Promise<void> {
   const pipeline = new PromptPipeline(
     "What is the oldest {thing} in the world? Keep your answer brief.",
     model.toString(),
@@ -15,6 +15,7 @@ async function prompt_model(model: LLM): Promise<void> {
   for await (const response of pipeline.gen_responses(
     { thing: ["bar", "tree", "book"] },
     model,
+    provider,
     1,
     1.0,
   )) {
@@ -35,6 +36,7 @@ async function prompt_model(model: LLM): Promise<void> {
   for await (const response of pipeline.gen_responses(
     { thing: ["bar", "tree", "book"] },
     model,
+    provider,
     2,
     1.0,
   )) {
@@ -63,6 +65,7 @@ async function prompt_model(model: LLM): Promise<void> {
   for await (const response of pipeline.gen_responses(
     { thing: ["bar", "tree", "book"] },
     model,
+    provider,
     2,
     1.0,
   )) {
@@ -86,13 +89,13 @@ async function prompt_model(model: LLM): Promise<void> {
 
 test("basic prompt pipeline with chatgpt", async () => {
   // Setup a simple pipeline with a prompt template, 1 variable and 3 input values
-  await prompt_model(NativeLLM.OpenAI_ChatGPT);
+  await prompt_model(NativeLLM.OpenAI_ChatGPT, LLMProvider.OpenAI);
 }, 20000);
 
 test("basic prompt pipeline with anthropic", async () => {
-  await prompt_model(NativeLLM.Claude_v1);
+  await prompt_model(NativeLLM.Claude_v1, LLMProvider.Anthropic);
 }, 40000);
 
 test("basic prompt pipeline with google palm2", async () => {
-  await prompt_model(NativeLLM.PaLM2_Chat_Bison);
+  await prompt_model(NativeLLM.PaLM2_Chat_Bison, LLMProvider.Google);
 }, 40000);

--- a/chainforge/react-server/src/backend/__test__/utils.test.ts
+++ b/chainforge/react-server/src/backend/__test__/utils.test.ts
@@ -9,7 +9,7 @@ import {
   extract_responses,
   merge_response_objs,
 } from "../utils";
-import { NativeLLM } from "../models";
+import { LLMProvider, NativeLLM } from "../models";
 import { expect, test } from "@jest/globals";
 import { RawLLMResponseObject } from "../typing";
 
@@ -68,7 +68,11 @@ test("openai chat completions", async () => {
   expect(query).toHaveProperty("temperature");
 
   // Extract responses, check their type
-  const resps = extract_responses(response, NativeLLM.OpenAI_ChatGPT);
+  const resps = extract_responses(
+    response,
+    NativeLLM.OpenAI_ChatGPT,
+    LLMProvider.OpenAI,
+  );
   expect(resps).toHaveLength(2);
   expect(typeof resps[0]).toBe("string");
 }, 20000);
@@ -86,7 +90,11 @@ test("openai text completions", async () => {
   expect(query).toHaveProperty("n");
 
   // Extract responses, check their type
-  const resps = extract_responses(response, NativeLLM.OpenAI_Davinci003);
+  const resps = extract_responses(
+    response,
+    NativeLLM.OpenAI_Davinci003,
+    LLMProvider.OpenAI,
+  );
   expect(resps).toHaveLength(2);
   expect(typeof resps[0]).toBe("string");
 }, 20000);
@@ -104,7 +112,11 @@ test("anthropic models", async () => {
   expect(query).toHaveProperty("max_tokens_to_sample");
 
   // Extract responses, check their type
-  const resps = extract_responses(response, NativeLLM.Claude_v1);
+  const resps = extract_responses(
+    response,
+    NativeLLM.Claude_v1,
+    LLMProvider.Anthropic,
+  );
   expect(resps).toHaveLength(1);
   expect(typeof resps[0]).toBe("string");
 }, 20000);
@@ -121,7 +133,11 @@ test("google palm2 models", async () => {
   expect(query).toHaveProperty("candidateCount");
 
   // Extract responses, check their type
-  let resps = extract_responses(response, NativeLLM.PaLM2_Chat_Bison);
+  let resps = extract_responses(
+    response,
+    NativeLLM.PaLM2_Chat_Bison,
+    LLMProvider.Google,
+  );
   expect(resps).toHaveLength(3);
   expect(typeof resps[0]).toBe("string");
   console.log(JSON.stringify(resps));
@@ -137,7 +153,11 @@ test("google palm2 models", async () => {
   expect(query).toHaveProperty("maxOutputTokens");
 
   // Extract responses, check their type
-  resps = extract_responses(response, NativeLLM.PaLM2_Chat_Bison);
+  resps = extract_responses(
+    response,
+    NativeLLM.PaLM2_Chat_Bison,
+    LLMProvider.Google,
+  );
   expect(resps).toHaveLength(3);
   expect(typeof resps[0]).toBe("string");
   console.log(JSON.stringify(resps));
@@ -153,7 +173,11 @@ test("aleph alpha model", async () => {
   expect(response).toHaveLength(3);
 
   // Extract responses, check their type
-  let resps = extract_responses(response, NativeLLM.Aleph_Alpha_Luminous_Base);
+  let resps = extract_responses(
+    response,
+    NativeLLM.Aleph_Alpha_Luminous_Base,
+    LLMProvider.Aleph_Alpha,
+  );
   expect(resps).toHaveLength(3);
   expect(typeof resps[0]).toBe("string");
   console.log(JSON.stringify(resps));
@@ -169,7 +193,11 @@ test("aleph alpha model", async () => {
   expect(response).toHaveLength(3);
 
   // Extract responses, check their type
-  resps = extract_responses(response, NativeLLM.Aleph_Alpha_Luminous_Base);
+  resps = extract_responses(
+    response,
+    NativeLLM.Aleph_Alpha_Luminous_Base,
+    LLMProvider.Aleph_Alpha,
+  );
   expect(resps).toHaveLength(3);
   expect(typeof resps[0]).toBe("string");
   console.log(JSON.stringify(resps));

--- a/chainforge/react-server/src/backend/models.ts
+++ b/chainforge/react-server/src/backend/models.ts
@@ -29,6 +29,7 @@ export enum NativeLLM {
   OpenAI_GPT4_32k = "gpt-4-32k",
   OpenAI_GPT4_32k_0314 = "gpt-4-32k-0314",
   OpenAI_GPT4_32k_0613 = "gpt-4-32k-0613",
+  OpenAI_Other = "Other (OpenAI)",
 
   // OpenAI Text Completions (deprecated)
   OpenAI_Davinci003 = "text-davinci-003",
@@ -69,6 +70,7 @@ export enum NativeLLM {
   Claude_v1_2 = "claude-v1.2",
   Claude_v1_3 = "claude-v1.3",
   Claude_v1_instant = "claude-instant-v1",
+  Claude_Other = "Other (Anthropic)",
 
   // Google models
   PaLM2_Text_Bison = "text-bison-001", // it's really models/text-bison-001, but that's confusing
@@ -79,10 +81,12 @@ export enum NativeLLM {
   GEMINI_v1_5_flash_8B = "gemini-1.5-flash-8b",
   GEMINI_v1_5_pro = "gemini-1.5-pro",
   GEMINI_v1_pro = "gemini-1.0-pro",
+  GEMINI_Other = "Other (Google)",
 
   // DeepSeek
   DeepSeek_Chat = "deepseek-chat",
   DeepSeek_Reasoner = "deepseek-reasoner",
+  DeepSeek_Other = "Other (DeepSeek)",
 
   // Aleph Alpha
   Aleph_Alpha_Luminous_Extended = "luminous-extended",
@@ -91,6 +95,7 @@ export enum NativeLLM {
   Aleph_Alpha_Luminous_Base = "luminous-base",
   Aleph_Alpha_Luminous_Supreme = "luminous-supreme",
   Aleph_Alpha_Luminous_SupremeControl = "luminous-supreme-control",
+  Aleph_Alpha_Other = "Other (AlephAlpha)",
 
   // HuggingFace Inference hosted models, suggested to users
   HF_MISTRAL_7B_INSTRUCT = "mistralai/Mistral-7B-Instruct-v0.1",
@@ -101,12 +106,10 @@ export enum NativeLLM {
   HF_DIALOGPT_LARGE = "microsoft/DialoGPT-large", // chat model
   HF_GPT2 = "gpt2",
   HF_BLOOM_560M = "bigscience/bloom-560m",
-  // HF_GPTJ_6B = "EleutherAI/gpt-j-6b",
-  // HF_LLAMA_7B = "decapoda-research/llama-7b-hf",
-
   // A special flag for a user-defined HuggingFace model endpoint.
   // The actual model name will be passed as a param to the LLM call function.
   HF_OTHER = "Other (HuggingFace)",
+
   Ollama = "ollama",
 
   Bedrock_Claude_2_1 = "anthropic.claude-v2:1",
@@ -129,6 +132,7 @@ export enum NativeLLM {
   Bedrock_Mistral_Mistral = "mistral.mistral-7b-instruct-v0:2",
   Bedrock_Mistral_Mistral_Large = "mistral.mistral-large-2402-v1:0",
   Bedrock_Mistral_Mixtral = "mistral.mixtral-8x7b-instruct-v0:1",
+  Bedrock_Other = "Other (Bedrock)",
 
   // Together.ai
   Together_ZeroOneAI_01ai_Yi_Chat_34B = "together/zero-one-ai/Yi-34B-Chat",
@@ -212,6 +216,7 @@ export enum NativeLLM {
   Together_Undi95_Toppy_M_7B = "together/Undi95/Toppy-M-7B",
   Together_WizardLM_WizardLM_v1_2_13B = "together/WizardLM/WizardLM-13B-V1.2",
   Together_upstage_Upstage_SOLAR_Instruct_v1_11B = "together/upstage/SOLAR-10.7B-Instruct-v1.0",
+  Together_Other = "together/Other (Together)",
 }
 
 export type LLM = string | NativeLLM;

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="chainforge",
-    version="0.3.2.9",
+    version="0.3.3.0",
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION

The specific model name in all providers can now be changed to a custom name:

<img width="574" alt="Screen Shot 2025-02-10 at 9 06 42 PM" src="https://github.com/user-attachments/assets/86803dc7-797f-4219-9a86-71f29363a381" />

where the user just must click `+Create <name>` to instantiate a new dropdown option. 

This was accomplished by swapping the dropdown list with `datalist`-like functionality via a custom widget (UI field) for `react-jsonform-schema`.

In the process, this PR changes a core part of ChainForge, touching `queryLLM` in `backend.ts` and `query.ts`, to require that querying LLMs pass an explicit, known `LLMProvider` to tell the backend what provider to query (rather than a weird reverse lookup, which was the previous method). 

This method has been tested to work on several providers, however there could be bugs still, given that this change touches  core functionality. 

Solves https://github.com/ianarawjo/ChainForge/issues/307. 