### PR TITLE
Give TextFields a maxHeight and wrap in ScrollArea

### DIFF
--- a/chainforge/react-server/src/TextFieldsNode.tsx
+++ b/chainforge/react-server/src/TextFieldsNode.tsx
@@ -7,7 +7,7 @@ import React, {
   MouseEventHandler,
 } from "react";
 import { Handle, Node, Position } from "reactflow";
-import { Textarea, Tooltip, Skeleton, ScrollArea, Group } from "@mantine/core";
+import { Textarea, Tooltip, Skeleton, ScrollArea } from "@mantine/core";
 import {
   IconTextPlus,
   IconEye,

--- a/chainforge/react-server/src/TextFieldsNode.tsx
+++ b/chainforge/react-server/src/TextFieldsNode.tsx
@@ -7,7 +7,7 @@ import React, {
   MouseEventHandler,
 } from "react";
 import { Handle, Node, Position } from "reactflow";
-import { Textarea, Tooltip, Skeleton } from "@mantine/core";
+import { Textarea, Tooltip, Skeleton, ScrollArea, Group } from "@mantine/core";
 import {
   IconTextPlus,
   IconEye,
@@ -73,6 +73,15 @@ const TextFieldsNode: React.FC<TextFieldsNodeProps> = ({ data, id }) => {
   const [fieldVisibility, setFieldVisibility] = useState<Dict<boolean>>(
     data.fields_visibility || {},
   );
+
+  // For when textfields exceed the TextFields Node max height,
+  // when we add a new field, this gives us a way to scroll to the bottom. Better UX.
+  const viewport = useRef<HTMLDivElement>(null);
+  const scrollToBottom = () =>
+    viewport?.current?.scrollTo({
+      top: viewport.current.scrollHeight,
+      behavior: "smooth",
+    });
 
   // Whether the text fields should be in a loading state
   const [isLoading, setIsLoading] = useState(false);
@@ -162,6 +171,10 @@ const TextFieldsNode: React.FC<TextFieldsNodeProps> = ({ data, id }) => {
     setTextfieldsValues(new_fields);
     setDataPropsForNode(id, { fields: new_fields });
     pingOutputNodes(id);
+
+    setTimeout(() => {
+      scrollToBottom();
+    }, 10);
 
     // Cycle suggestions when new field is created
     // aiSuggestionsManager.cycleSuggestions();
@@ -493,7 +506,11 @@ const TextFieldsNode: React.FC<TextFieldsNodeProps> = ({ data, id }) => {
         }
       />
       <Skeleton visible={isLoading}>
-        <div ref={setRef}>{textFields}</div>
+        <div ref={setRef} className="nodrag nowheel">
+          <ScrollArea.Autosize mah={580} type="hover" viewportRef={viewport}>
+            {textFields}
+          </ScrollArea.Autosize>
+        </div>
       </Skeleton>
       <Handle
         type="source"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="chainforge",
-    version="0.3.3.0",
+    version="0.3.3.1",
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION
`TextFieldsNode`s have not been limited by height. When extending the TextField beyond 4-5 long texts, this quickly fits the screen size. While users can transition to using `TabularDataNode`s in this case, it is not straightforward. To avoid clutter, this PR wraps the inner textareas in a `ScrollArea` that activates when a max height is exceeded, clipping the height of the node. 