### PR TITLE
Better Table Tiew, optimized string storage

### DIFF
--- a/chainforge/react-server/package-lock.json
+++ b/chainforge/react-server/package-lock.json
@@ -65,7 +65,7 @@
         "lodash": "^4.17.21",
         "lz-string": "^1.5.0",
         "mantine-contextmenu": "^6.1.0",
-        "mantine-react-table": "^1.0.0-beta.8",
+        "mantine-react-table": "^1.3.4",
         "markdown-it": "^13.0.1",
         "mathjs": "^11.8.2",
         "mdast-util-from-markdown": "^2.0.0",
@@ -6191,11 +6191,11 @@
       }
     },
     "node_modules/@tanstack/react-table": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.10.0.tgz",
-      "integrity": "sha512-FNhKE3525hryvuWw90xRbP16qNiq7OLJkDZopOKcwyktErLi1ibJzAN9DFwA/gR1br9SK4StXZh9JPvp9izrrQ==",
+      "version": "8.10.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.10.6.tgz",
+      "integrity": "sha512-D0VEfkIYnIKdy6SHiBNEaMc4SxO+MV7ojaPhRu8jP933/gbMi367+Wul2LxkdovJ5cq6awm0L1+jgxdS/unzIg==",
       "dependencies": {
-        "@tanstack/table-core": "8.10.0"
+        "@tanstack/table-core": "8.10.6"
       },
       "engines": {
         "node": ">=12"
@@ -6210,11 +6210,11 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.0.0-beta.60",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.60.tgz",
-      "integrity": "sha512-F0wL9+byp7lf/tH6U5LW0ZjBqs+hrMXJrj5xcIGcklI0pggvjzMNW9DdIBcyltPNr6hmHQ0wt8FDGe1n1ZAThA==",
+      "version": "3.0.0-beta.63",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.63.tgz",
+      "integrity": "sha512-n4aaZs3g9U2oZjFp8dAeT1C2g4rr/3lbCo2qWbD9NquajKnGx7R+EfLBAHJ6pVMmfsTMZ0XCBwkIs7U74R/s0A==",
       "dependencies": {
-        "@tanstack/virtual-core": "3.0.0-beta.60"
+        "@tanstack/virtual-core": "3.0.0-beta.63"
       },
       "funding": {
         "type": "github",
@@ -6225,9 +6225,9 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.0.tgz",
-      "integrity": "sha512-e701yAJ18aGDP6mzVworlFAmQ+gi3Wtqx5mGZUe2BUv4W4D80dJxUfkHdtEGJ6GryAnlCCNTej7eaJiYmPhyYg==",
+      "version": "8.10.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.6.tgz",
+      "integrity": "sha512-9t8brthhAmCBIjzk7fCDa/kPKoLQTtA31l9Ir76jYxciTlHU61r/6gYm69XF9cbg9n88gVL5y7rNpeJ2dc1AFA==",
       "engines": {
         "node": ">=12"
       },
@@ -6237,9 +6237,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.0.0-beta.60",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.60.tgz",
-      "integrity": "sha512-QlCdhsV1+JIf0c0U6ge6SQmpwsyAT0oQaOSZk50AtEeAyQl9tQrd6qCHAslxQpgphrfe945abvKG8uYvw3hIGA==",
+      "version": "3.0.0-beta.63",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.63.tgz",
+      "integrity": "sha512-KhhfRYSoQpl0y+2axEw+PJZd/e/9p87PDpPompxcXnweNpt9ZHCT/HuNx7MKM9PVY/xzg9xJSWxwnSCrO+d6PQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -17692,13 +17692,13 @@
       }
     },
     "node_modules/mantine-react-table": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mantine-react-table/-/mantine-react-table-1.3.0.tgz",
-      "integrity": "sha512-ljAd9ZI7S89glI8OGbM5DsNHzInZPfigbeDXboR5gLGPuuseLVgezlVjqV1h8MUQkY06++d9ah9zsMLr2VNxlQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mantine-react-table/-/mantine-react-table-1.3.4.tgz",
+      "integrity": "sha512-rD0CaeC4RCU7k/ZKvfj5ijFFMd4clGpeg/EwMcogYFioZjj8aNfD78osTNNYr90AnOAFGnd7ZnderLK89+W1ZQ==",
       "dependencies": {
         "@tanstack/match-sorter-utils": "8.8.4",
-        "@tanstack/react-table": "8.10.0",
-        "@tanstack/react-virtual": "3.0.0-beta.60"
+        "@tanstack/react-table": "8.10.6",
+        "@tanstack/react-virtual": "3.0.0-beta.63"
       },
       "engines": {
         "node": ">=14"
@@ -17712,7 +17712,7 @@
         "@mantine/core": "^6.0",
         "@mantine/dates": "^6.0",
         "@mantine/hooks": "^6.0",
-        "@tabler/icons-react": ">=2.23.0",
+        "@tabler/icons-react": ">=2.23",
         "react": ">=18.0",
         "react-dom": ">=18.0"
       }

--- a/chainforge/react-server/package.json
+++ b/chainforge/react-server/package.json
@@ -63,7 +63,7 @@
     "lodash": "^4.17.21",
     "lz-string": "^1.5.0",
     "mantine-contextmenu": "^6.1.0",
-    "mantine-react-table": "^1.0.0-beta.8",
+    "mantine-react-table": "^1.3.4",
     "markdown-it": "^13.0.1",
     "mathjs": "^11.8.2",
     "mdast-util-from-markdown": "^2.0.0",

--- a/chainforge/react-server/src/AiPopover.tsx
+++ b/chainforge/react-server/src/AiPopover.tsx
@@ -299,8 +299,9 @@ export function AIGenReplaceTablePopover({
   // Check if there are any non-empty rows
   const nonEmptyRows = useMemo(
     () =>
-      values.filter((row) => Object.values(row).some((val) => StringLookup.get(val)?.trim()))
-        .length,
+      values.filter((row) =>
+        Object.values(row).some((val) => StringLookup.get(val)?.trim()),
+      ).length,
     [values],
   );
 
@@ -369,7 +370,9 @@ export function AIGenReplaceTablePopover({
       const tableRows = values
         .slice(0, -1) // Remove the last empty row
         .map((row) =>
-          tableColumns.map((col) => StringLookup.get(row[col])?.trim() || "").join(" | "),
+          tableColumns
+            .map((col) => StringLookup.get(row[col])?.trim() || "")
+            .join(" | "),
         );
 
       const tableInput = {
@@ -419,7 +422,9 @@ export function AIGenReplaceTablePopover({
       const tableRows = values
         .slice(0, emptyLastRow ? -1 : values.length)
         .map((row) =>
-          tableColumns.map((col) => StringLookup.get(row[col.key])?.trim() || "").join(" | "),
+          tableColumns
+            .map((col) => StringLookup.get(row[col.key])?.trim() || "")
+            .join(" | "),
         );
 
       const tableInput = {

--- a/chainforge/react-server/src/AiPopover.tsx
+++ b/chainforge/react-server/src/AiPopover.tsx
@@ -42,6 +42,7 @@ import {
   VarsContext,
 } from "./backend/typing";
 import { v4 as uuidv4 } from "uuid";
+import { StringLookup } from "./backend/cache";
 
 const zeroGap = { gap: "0rem" };
 const popoverShadow = "rgb(38, 57, 77) 0px 10px 30px -14px";
@@ -298,7 +299,7 @@ export function AIGenReplaceTablePopover({
   // Check if there are any non-empty rows
   const nonEmptyRows = useMemo(
     () =>
-      values.filter((row) => Object.values(row).some((val) => val?.trim()))
+      values.filter((row) => Object.values(row).some((val) => StringLookup.get(val)?.trim()))
         .length,
     [values],
   );
@@ -368,7 +369,7 @@ export function AIGenReplaceTablePopover({
       const tableRows = values
         .slice(0, -1) // Remove the last empty row
         .map((row) =>
-          tableColumns.map((col) => row[col]?.trim() || "").join(" | "),
+          tableColumns.map((col) => StringLookup.get(row[col])?.trim() || "").join(" | "),
         );
 
       const tableInput = {
@@ -418,7 +419,7 @@ export function AIGenReplaceTablePopover({
       const tableRows = values
         .slice(0, emptyLastRow ? -1 : values.length)
         .map((row) =>
-          tableColumns.map((col) => row[col.key]?.trim() || "").join(" | "),
+          tableColumns.map((col) => StringLookup.get(row[col.key])?.trim() || "").join(" | "),
         );
 
       const tableInput = {

--- a/chainforge/react-server/src/App.tsx
+++ b/chainforge/react-server/src/App.tsx
@@ -70,7 +70,7 @@ import "lazysizes/plugins/attrchange/ls.attrchange";
 // State management (from https://reactflow.dev/docs/guides/state-management/)
 import { shallow } from "zustand/shallow";
 import useStore, { StoreHandles } from "./store";
-import StorageCache from "./backend/cache";
+import StorageCache, { StringLookup } from "./backend/cache";
 import { APP_IS_RUNNING_LOCALLY, browserTabIsActive } from "./backend/utils";
 import { Dict, JSONCompatible, LLMSpec } from "./backend/typing";
 import {
@@ -431,6 +431,8 @@ const App = () => {
 
     setNodes(starting_nodes);
     setEdges([]);
+
+    StorageCache.clear();
     if (rfInstance) rfInstance.setViewport({ x: 200, y: 80, zoom: 1 });
   }, [setNodes, setEdges, resetLLMColors, rfInstance]);
 
@@ -481,7 +483,7 @@ const App = () => {
       false,
     ) as Dict;
     if (saved_flow) {
-      StorageCache.loadFromLocalStorage("chainforge-state");
+      StorageCache.loadFromLocalStorage("chainforge-state", true);
       importGlobalStateFromCache();
       loadFlow(saved_flow, rf_inst);
     }
@@ -530,6 +532,7 @@ const App = () => {
       if (!flowJSON.cache) {
         // Support for loading old flows w/o cache data:
         loadFlow(flowJSON, rf);
+        StringLookup.restoreFrom([]); // manually clear the string lookup table
         return;
       }
 

--- a/chainforge/react-server/src/CodeEvaluatorNode.tsx
+++ b/chainforge/react-server/src/CodeEvaluatorNode.tsx
@@ -53,6 +53,7 @@ import {
 import { Status } from "./StatusIndicatorComponent";
 import { executejs, executepy, grabResponses } from "./backend/backend";
 import { AlertModalContext } from "./AlertModal";
+import { StringLookup } from "./backend/cache";
 
 // Whether we are running on localhost or not, and hence whether
 // we have access to the Flask backend for, e.g., Python code evaluation.
@@ -540,7 +541,7 @@ The Python interpeter in the browser is Pyodide. You may not be able to run some
               resp_obj.responses.map((r) => {
                 // Carry over the response text, prompt, prompt fill history (vars), and llm data
                 const o: TemplateVarInfo = {
-                  text: typeof r === "string" ? escapeBraces(r) : undefined,
+                  text: typeof r === "number" ? escapeBraces(StringLookup.get(r)!) : ((typeof r === "string") ? escapeBraces(r) : undefined),
                   image:
                     typeof r === "object" && r.t === "img" ? r.d : undefined,
                   prompt: resp_obj.prompt,
@@ -549,6 +550,8 @@ The Python interpeter in the browser is Pyodide. You may not be able to run some
                   llm: resp_obj.llm,
                   uid: resp_obj.uid,
                 };
+
+                o.text = o.text !== undefined ? StringLookup.intern(o.text as string) : undefined;
 
                 // Carry over any chat history
                 if (resp_obj.chat_history)

--- a/chainforge/react-server/src/CodeEvaluatorNode.tsx
+++ b/chainforge/react-server/src/CodeEvaluatorNode.tsx
@@ -541,7 +541,12 @@ The Python interpeter in the browser is Pyodide. You may not be able to run some
               resp_obj.responses.map((r) => {
                 // Carry over the response text, prompt, prompt fill history (vars), and llm data
                 const o: TemplateVarInfo = {
-                  text: typeof r === "number" ? escapeBraces(StringLookup.get(r)!) : ((typeof r === "string") ? escapeBraces(r) : undefined),
+                  text:
+                    typeof r === "number"
+                      ? escapeBraces(StringLookup.get(r)!)
+                      : typeof r === "string"
+                        ? escapeBraces(r)
+                        : undefined,
                   image:
                     typeof r === "object" && r.t === "img" ? r.d : undefined,
                   prompt: resp_obj.prompt,
@@ -551,7 +556,10 @@ The Python interpeter in the browser is Pyodide. You may not be able to run some
                   uid: resp_obj.uid,
                 };
 
-                o.text = o.text !== undefined ? StringLookup.intern(o.text as string) : undefined;
+                o.text =
+                  o.text !== undefined
+                    ? StringLookup.intern(o.text as string)
+                    : undefined;
 
                 // Carry over any chat history
                 if (resp_obj.chat_history)

--- a/chainforge/react-server/src/GlobalSettingsModal.tsx
+++ b/chainforge/react-server/src/GlobalSettingsModal.tsx
@@ -271,7 +271,7 @@ const GlobalSettingsModal = forwardRef<GlobalSettingsModalRef, object>(
 
       // Load image compression settings from cache (if possible)
       const cachedImgCompr = (
-        StorageCache.loadFromLocalStorage("imageCompression") as Dict
+        StorageCache.loadFromLocalStorage("imageCompression", false) as Dict
       )?.value as boolean | undefined;
       if (typeof cachedImgCompr === "boolean") {
         setImageCompression(cachedImgCompr);

--- a/chainforge/react-server/src/JoinNode.tsx
+++ b/chainforge/react-server/src/JoinNode.tsx
@@ -80,7 +80,7 @@ const displayJoinedTexts = (
       typeof info !== "string"
         ? typeof info.llm === "string" || typeof info.llm === "number"
           ? StringLookup.get(info.llm)
-          : info.llm?.name
+          : StringLookup.get(info.llm?.name)
         : "";
     const ps = (
       <pre className="small-response">
@@ -267,7 +267,12 @@ const JoinNode: React.FC<JoinNodeProps> = ({ data, id }) => {
         if (groupByVar !== "A") vars[varname] = var_val;
         return {
           text: joinTexts(
-            resp_objs.map((r) => ((typeof r === "string" || typeof r === "number" ? StringLookup.get(r) : StringLookup.get(r.text)) ?? "")),
+            resp_objs.map(
+              (r) =>
+                (typeof r === "string" || typeof r === "number"
+                  ? StringLookup.get(r)
+                  : StringLookup.get(r.text)) ?? "",
+            ),
             formatting,
           ),
           fill_history: isMetavar ? {} : vars,
@@ -284,7 +289,12 @@ const JoinNode: React.FC<JoinNodeProps> = ({ data, id }) => {
           countNumLLMs(unspecGroup) > 1 ? undefined : unspecGroup[0].llm;
         joined_texts.push({
           text: joinTexts(
-            unspecGroup.map((u) => ((typeof u === "string" || typeof u === "number" ? StringLookup.get(u) : StringLookup.get(u.text)) ?? "")),
+            unspecGroup.map(
+              (u) =>
+                (typeof u === "string" || typeof u === "number"
+                  ? StringLookup.get(u)
+                  : StringLookup.get(u.text)) ?? "",
+            ),
             formatting,
           ),
           fill_history: {},
@@ -326,7 +336,10 @@ const JoinNode: React.FC<JoinNodeProps> = ({ data, id }) => {
           let joined_texts: (TemplateVarInfo | string)[] = [];
           const [groupedRespsByLLM, nonLLMRespGroup] = groupResponsesBy(
             resp_objs,
-            (r) => (typeof r.llm === "string" || typeof r.llm === "number" ? StringLookup.get(r.llm) : r.llm?.key),
+            (r) =>
+              typeof r.llm === "string" || typeof r.llm === "number"
+                ? StringLookup.get(r.llm)
+                : r.llm?.key,
           );
           // eslint-disable-next-line
           Object.entries(groupedRespsByLLM).forEach(([llm_key, resp_objs]) => {
@@ -353,7 +366,12 @@ const JoinNode: React.FC<JoinNodeProps> = ({ data, id }) => {
             setDataPropsForNode(id, { fields: joined_texts });
           } else {
             let joined_texts: string | TemplateVarInfo = joinTexts(
-              resp_objs.map((r) => ((typeof r === "string" || typeof r === "number" ? StringLookup.get(r) : StringLookup.get(r.text)) ?? "")),
+              resp_objs.map(
+                (r) =>
+                  (typeof r === "string" || typeof r === "number"
+                    ? StringLookup.get(r)
+                    : StringLookup.get(r.text)) ?? "",
+              ),
               formatting,
             );
 

--- a/chainforge/react-server/src/JoinNode.tsx
+++ b/chainforge/react-server/src/JoinNode.tsx
@@ -27,7 +27,7 @@ import {
   getVarsAndMetavars,
   cleanMetavarsFilterFunc,
 } from "./backend/utils";
-import StorageCache from "./backend/cache";
+import StorageCache, { StringLookup } from "./backend/cache";
 import { ResponseBox } from "./ResponseBoxes";
 import {
   Dict,
@@ -267,7 +267,7 @@ const JoinNode: React.FC<JoinNodeProps> = ({ data, id }) => {
         if (groupByVar !== "A") vars[varname] = var_val;
         return {
           text: joinTexts(
-            resp_objs.map((r) => (typeof r === "string" ? r : r.text ?? "")),
+            resp_objs.map((r) => ((typeof r === "string" || typeof r === "number" ? StringLookup.get(r) : StringLookup.get(r.text)) ?? "")),
             formatting,
           ),
           fill_history: isMetavar ? {} : vars,
@@ -284,7 +284,7 @@ const JoinNode: React.FC<JoinNodeProps> = ({ data, id }) => {
           countNumLLMs(unspecGroup) > 1 ? undefined : unspecGroup[0].llm;
         joined_texts.push({
           text: joinTexts(
-            unspecGroup.map((u) => (typeof u === "string" ? u : u.text ?? "")),
+            unspecGroup.map((u) => ((typeof u === "string" || typeof u === "number" ? StringLookup.get(u) : StringLookup.get(u.text)) ?? "")),
             formatting,
           ),
           fill_history: {},
@@ -337,7 +337,7 @@ const JoinNode: React.FC<JoinNodeProps> = ({ data, id }) => {
           if (nonLLMRespGroup.length > 0)
             joined_texts.push(
               joinTexts(
-                nonLLMRespGroup.map((t) => t.text ?? ""),
+                nonLLMRespGroup.map((t) => StringLookup.get(t.text) ?? ""),
                 formatting,
               ),
             );
@@ -353,7 +353,7 @@ const JoinNode: React.FC<JoinNodeProps> = ({ data, id }) => {
             setDataPropsForNode(id, { fields: joined_texts });
           } else {
             let joined_texts: string | TemplateVarInfo = joinTexts(
-              resp_objs.map((r) => (typeof r === "string" ? r : r.text ?? "")),
+              resp_objs.map((r) => ((typeof r === "string" || typeof r === "number" ? StringLookup.get(r) : StringLookup.get(r.text)) ?? "")),
               formatting,
             );
 

--- a/chainforge/react-server/src/JoinNode.tsx
+++ b/chainforge/react-server/src/JoinNode.tsx
@@ -78,8 +78,8 @@ const displayJoinedTexts = (
   return textInfos.map((info, idx) => {
     const llm_name =
       typeof info !== "string"
-        ? typeof info.llm === "string"
-          ? info.llm
+        ? typeof info.llm === "string" || typeof info.llm === "number"
+          ? StringLookup.get(info.llm)
           : info.llm?.name
         : "";
     const ps = (
@@ -326,7 +326,7 @@ const JoinNode: React.FC<JoinNodeProps> = ({ data, id }) => {
           let joined_texts: (TemplateVarInfo | string)[] = [];
           const [groupedRespsByLLM, nonLLMRespGroup] = groupResponsesBy(
             resp_objs,
-            (r) => (typeof r.llm === "string" ? r.llm : r.llm?.key),
+            (r) => (typeof r.llm === "string" || typeof r.llm === "number" ? StringLookup.get(r.llm) : r.llm?.key),
           );
           // eslint-disable-next-line
           Object.entries(groupedRespsByLLM).forEach(([llm_key, resp_objs]) => {

--- a/chainforge/react-server/src/LLMEvalNode.tsx
+++ b/chainforge/react-server/src/LLMEvalNode.tsx
@@ -41,6 +41,7 @@ import CancelTracker from "./backend/canceler";
 import { PromptInfo, PromptListModal, PromptListPopover } from "./PromptNode";
 import { useDisclosure } from "@mantine/hooks";
 import { PromptTemplate } from "./backend/template";
+import { StringLookup } from "./backend/cache";
 
 // The default prompt shown in gray highlights to give people a good example of an evaluation prompt.
 const PLACEHOLDER_PROMPT =
@@ -72,7 +73,7 @@ const DEFAULT_LLM_ITEM = (() => {
   const item = [initLLMProviders.find((i) => i.base_model === "gpt-4")].map(
     (i) => ({
       key: uuid(),
-      settings: getDefaultModelSettings((i as LLMSpec).base_model),
+      settings: getDefaultModelSettings(StringLookup.get(i?.base_model) as string),
       ...i,
     }),
   )[0];
@@ -375,7 +376,7 @@ const LLMEvaluatorNode: React.FC<LLMEvaluatorNodeProps> = ({ data, id }) => {
           const inputs = resp_objs
             .map((obj: LLMResponse) =>
               obj.responses.map((r: LLMResponseData) => ({
-                text: typeof r === "string" ? r : undefined,
+                text: typeof r === "string" || typeof r === "number" ? r : undefined,
                 image: typeof r === "object" && r.t === "img" ? r.d : undefined,
                 fill_history: obj.vars,
                 metavars: obj.metavars,

--- a/chainforge/react-server/src/LLMEvalNode.tsx
+++ b/chainforge/react-server/src/LLMEvalNode.tsx
@@ -73,7 +73,9 @@ const DEFAULT_LLM_ITEM = (() => {
   const item = [initLLMProviders.find((i) => i.base_model === "gpt-4")].map(
     (i) => ({
       key: uuid(),
-      settings: getDefaultModelSettings(StringLookup.get(i?.base_model) as string),
+      settings: getDefaultModelSettings(
+        StringLookup.get(i?.base_model) as string,
+      ),
       ...i,
     }),
   )[0];
@@ -376,7 +378,10 @@ const LLMEvaluatorNode: React.FC<LLMEvaluatorNodeProps> = ({ data, id }) => {
           const inputs = resp_objs
             .map((obj: LLMResponse) =>
               obj.responses.map((r: LLMResponseData) => ({
-                text: typeof r === "string" || typeof r === "number" ? r : undefined,
+                text:
+                  typeof r === "string" || typeof r === "number"
+                    ? r
+                    : undefined,
                 image: typeof r === "object" && r.t === "img" ? r.d : undefined,
                 fill_history: obj.vars,
                 metavars: obj.metavars,

--- a/chainforge/react-server/src/LLMResponseInspector.tsx
+++ b/chainforge/react-server/src/LLMResponseInspector.tsx
@@ -493,7 +493,7 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
 
       // Regroup responses by batch ID
       let responses = batchedResponses;
-      let numResponsesDisplayed = 0;
+      // let numResponsesDisplayed = 0;
       const selected_vars = multiSelectValue;
       const empty_cell_text =
         searchValue.length > 0 ? "(no match)" : "(no data)";
@@ -570,7 +570,7 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
                 (typeof r === "string" || typeof r === "number") &&
                 search_regex.test(StringLookup.get(r) ?? ""),
             );
-            numResponsesDisplayed += filtered_resps.length;
+            // numResponsesDisplayed += filtered_resps.length;
             if (filterBySearchValue) return filtered_resps;
             else return responses;
           };
@@ -1070,7 +1070,7 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
         setResponseDivs(divs);
       }
 
-      setNumMatches(numResponsesDisplayed);
+      // setNumMatches(numResponsesDisplayed);
     });
   };
 
@@ -1112,8 +1112,8 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
         <TextInput
           id="search_bar"
           label={
-            "Find" +
-            (searchValue.length > 0 ? ` (${numMatches}/${numResponses})` : "")
+            "Find"
+            // + (searchValue.length > 0 ? ` (${numMatches}/${numResponses})` : "")
           }
           autoComplete="off"
           size={sz}

--- a/chainforge/react-server/src/LLMResponseInspector.tsx
+++ b/chainforge/react-server/src/LLMResponseInspector.tsx
@@ -4,7 +4,13 @@
  * Separated from ReactFlow node UI so that it can
  * be deployed in multiple locations.
  */
-import React, { useState, useEffect, useRef, useMemo, useTransition } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  useTransition,
+} from "react";
 import {
   MultiSelect,
   Table,
@@ -56,7 +62,9 @@ import { StringLookup } from "./backend/cache";
 
 // Helper funcs
 const getLLMName = (resp_obj: LLMResponse) =>
-  ((typeof resp_obj?.llm === "string" || typeof resp_obj?.llm === "number") ? StringLookup.get(resp_obj.llm) : StringLookup.get(resp_obj?.llm?.name)) ?? "(string lookup failed)";
+  (typeof resp_obj?.llm === "string" || typeof resp_obj?.llm === "number"
+    ? StringLookup.get(resp_obj.llm)
+    : StringLookup.get(resp_obj?.llm?.name)) ?? "(string lookup failed)";
 const escapeRegExp = (txt: string) =>
   txt.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 
@@ -314,7 +322,7 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
     (state) => state.getColorForLLMAndSetIfNotFound,
   );
 
-    // Debounce helpers
+  // Debounce helpers
   const debounceTimeoutRef: DebounceRef = useRef(null);
   const debounce = genDebounceFunc(debounceTimeoutRef);
 
@@ -323,11 +331,11 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
 
   // Show loading spinner not every update, but only after a certain time has passed during loading.
   const [showLoadingSpinner, setShowLoadingSpinner] = useState(false);
-  const [showLoadingSpinnerTimeout, setShowLoadingSpinnerTimeout] = useState<NodeJS.Timeout | null>(null);
+  const [showLoadingSpinnerTimeout, setShowLoadingSpinnerTimeout] =
+    useState<NodeJS.Timeout | null>(null);
   useEffect(() => {
     if (isPending && !showLoadingSpinner) {
-      if (showLoadingSpinnerTimeout)
-        clearTimeout(showLoadingSpinnerTimeout);
+      if (showLoadingSpinnerTimeout) clearTimeout(showLoadingSpinnerTimeout);
       const timeout = setTimeout(() => setShowLoadingSpinner(true), 500); // Delay by 500ms
       setShowLoadingSpinnerTimeout(timeout);
     } else {
@@ -362,7 +370,9 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
         (found_llms as Set<string>).add(getLLMName(res_obj));
       });
       found_vars = Array.from(found_vars);
-      found_metavars = Array.from(found_metavars).filter(cleanMetavarsFilterFunc);
+      found_metavars = Array.from(found_metavars).filter(
+        cleanMetavarsFilterFunc,
+      );
       found_llms = Array.from(found_llms);
 
       // Whether there's some evaluation scores in the responses
@@ -423,7 +433,9 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
         // If the multi select vars changed and no longer includes the user's selected value,
         // erase every value that went away, then early exit because useEffect is going to immediately recall this function:
         setMultiSelectValue(
-          multiSelectValue.filter((name) => msvars.some((o) => o.value === name)),
+          multiSelectValue.filter((name) =>
+            msvars.some((o) => o.value === name),
+          ),
         );
         return; // useEffect will replot with the new values
       }
@@ -432,7 +444,8 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
       let responses = batchedResponses;
       let numResponsesDisplayed = 0;
       const selected_vars = multiSelectValue;
-      const empty_cell_text = searchValue.length > 0 ? "(no match)" : "(no data)";
+      const empty_cell_text =
+        searchValue.length > 0 ? "(no match)" : "(no data)";
       const search_regex = new RegExp(
         escapeRegExp(searchValue),
         caseSensitive ? "" : "i",
@@ -442,7 +455,9 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
       if (searchValue.length > 0 && filterBySearchValue)
         responses = responses.filter((res_obj) =>
           res_obj.responses.some(
-            (r) => (typeof r === "string" || typeof r === "number") && search_regex.test(StringLookup.get(r) ?? ""),
+            (r) =>
+              (typeof r === "string" || typeof r === "number") &&
+              search_regex.test(StringLookup.get(r) ?? ""),
           ),
         );
 
@@ -500,7 +515,9 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
           const respsFilterFunc = (responses: LLMResponseData[]) => {
             if (searchValue.length === 0) return responses;
             const filtered_resps = responses.filter(
-              (r) => (typeof r === "string" || typeof r === "number") && search_regex.test(StringLookup.get(r) ?? ""),
+              (r) =>
+                (typeof r === "string" || typeof r === "number") &&
+                search_regex.test(StringLookup.get(r) ?? ""),
             );
             numResponsesDisplayed += filtered_resps.length;
             if (filterBySearchValue) return filtered_resps;
@@ -595,7 +612,11 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
               return acc;
             }, new Set<string>()),
           );
-          colnames = colnames.concat(found_sel_var_vals.map(v => (StringLookup.get(v) ?? "(string lookup failed)")));
+          colnames = colnames.concat(
+            found_sel_var_vals.map(
+              (v) => StringLookup.get(v) ?? "(string lookup failed)",
+            ),
+          );
         }
 
         const getVar = (r: LLMResponse, v: string) =>
@@ -732,7 +753,9 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
             let fixed_width = 100;
             const side_by_side_resps = wideFormat;
             if (side_by_side_resps && eatenvars.length > 0) {
-              const num_llms = Array.from(new Set(resps.map(getLLMName))).length;
+              const num_llms = Array.from(
+                new Set(resps.map(getLLMName)),
+              ).length;
               fixed_width = Math.max(20, Math.trunc(100 / num_llms)) - 1; // 20% width is lowest we will go (5 LLM response boxes max)
             }
             const resp_boxes = generateResponseBoxes(
@@ -775,14 +798,18 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
             group_name === "$LLM"
               ? groupResponsesBy(resps, getLLMName)
               : groupResponsesBy(resps, (r) =>
-                  group_name in r.vars ? StringLookup.get(r.vars[group_name]) : null,
+                  group_name in r.vars
+                    ? StringLookup.get(r.vars[group_name])
+                    : null,
                 );
           const get_header =
             group_name === "$LLM"
               ? (key: string, val?: string) => (
                   <div
                     key={val}
-                    style={{ backgroundColor: val ? color_for_llm(val) : "#eee" }}
+                    style={{
+                      backgroundColor: val ? color_for_llm(val) : "#eee",
+                    }}
                     className="response-llm-header"
                   >
                     {val}

--- a/chainforge/react-server/src/LLMResponseInspector.tsx
+++ b/chainforge/react-server/src/LLMResponseInspector.tsx
@@ -4,7 +4,7 @@
  * Separated from ReactFlow node UI so that it can
  * be deployed in multiple locations.
  */
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useState, useEffect, useRef, useMemo, useTransition } from "react";
 import {
   MultiSelect,
   Table,
@@ -17,6 +17,8 @@ import {
   TextInput,
   Stack,
   ScrollArea,
+  LoadingOverlay,
+  Skeleton,
 } from "@mantine/core";
 import { useToggle } from "@mantine/hooks";
 import {
@@ -34,6 +36,8 @@ import {
   batchResponsesByUID,
   cleanMetavarsFilterFunc,
   llmResponseDataToString,
+  DebounceRef,
+  genDebounceFunc,
 } from "./backend/utils";
 import {
   ResponseBox,
@@ -310,6 +314,31 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
     (state) => state.getColorForLLMAndSetIfNotFound,
   );
 
+    // Debounce helpers
+  const debounceTimeoutRef: DebounceRef = useRef(null);
+  const debounce = genDebounceFunc(debounceTimeoutRef);
+
+  // Offload intensive computation to redraw and avoid blocking UI
+  const [isPending, startTransition] = useTransition();
+
+  // Show loading spinner not every update, but only after a certain time has passed during loading.
+  const [showLoadingSpinner, setShowLoadingSpinner] = useState(false);
+  const [showLoadingSpinnerTimeout, setShowLoadingSpinnerTimeout] = useState<NodeJS.Timeout | null>(null);
+  useEffect(() => {
+    if (isPending && !showLoadingSpinner) {
+      if (showLoadingSpinnerTimeout)
+        clearTimeout(showLoadingSpinnerTimeout);
+      const timeout = setTimeout(() => setShowLoadingSpinner(true), 500); // Delay by 500ms
+      setShowLoadingSpinnerTimeout(timeout);
+    } else {
+      if (showLoadingSpinnerTimeout) {
+        clearTimeout(showLoadingSpinnerTimeout);
+        setShowLoadingSpinnerTimeout(null);
+      }
+      setShowLoadingSpinner(false); // Hide immediately when isPending is false
+    }
+  }, [isPending]);
+
   // Update the visualization whenever the jsonResponses or MultiSelect values change:
   const triggerRedraw = () => {
     if (
@@ -318,517 +347,522 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
     )
       return;
 
-    // Find all vars in responses
-    let found_vars: Array<string> | Set<string> = new Set<string>();
-    let found_metavars: Array<string> | Set<string> = new Set<string>();
-    let found_llms: Array<string> | Set<string> = new Set<string>();
-    batchedResponses.forEach((res_obj) => {
-      Object.keys(res_obj.vars).forEach((v) =>
-        (found_vars as Set<string>).add(v),
+    startTransition(() => {
+      // Find all vars in responses
+      let found_vars: Array<string> | Set<string> = new Set<string>();
+      let found_metavars: Array<string> | Set<string> = new Set<string>();
+      let found_llms: Array<string> | Set<string> = new Set<string>();
+      batchedResponses.forEach((res_obj) => {
+        Object.keys(res_obj.vars).forEach((v) =>
+          (found_vars as Set<string>).add(v),
+        );
+        Object.keys(res_obj.metavars).forEach((v) =>
+          (found_metavars as Set<string>).add(v),
+        );
+        (found_llms as Set<string>).add(getLLMName(res_obj));
+      });
+      found_vars = Array.from(found_vars);
+      found_metavars = Array.from(found_metavars).filter(cleanMetavarsFilterFunc);
+      found_llms = Array.from(found_llms);
+
+      // Whether there's some evaluation scores in the responses
+      const contains_eval_res = batchedResponses.some(
+        (res_obj) => res_obj.eval_res !== undefined,
       );
-      Object.keys(res_obj.metavars).forEach((v) =>
-        (found_metavars as Set<string>).add(v),
-      );
-      (found_llms as Set<string>).add(getLLMName(res_obj));
-    });
-    found_vars = Array.from(found_vars);
-    found_metavars = Array.from(found_metavars).filter(cleanMetavarsFilterFunc);
-    found_llms = Array.from(found_llms);
+      const contains_multi_evals = contains_eval_res
+        ? batchedResponses.some((res_obj) => {
+            const items = res_obj.eval_res?.items;
+            return items && items.length > 0 && typeof items[0] === "object";
+          })
+        : false;
+      setShowEvalScoreOptions(contains_eval_res);
 
-    // Whether there's some evaluation scores in the responses
-    const contains_eval_res = batchedResponses.some(
-      (res_obj) => res_obj.eval_res !== undefined,
-    );
-    const contains_multi_evals = contains_eval_res
-      ? batchedResponses.some((res_obj) => {
-          const items = res_obj.eval_res?.items;
-          return items && items.length > 0 && typeof items[0] === "object";
-        })
-      : false;
-    setShowEvalScoreOptions(contains_eval_res);
+      // Set the variables accessible in the MultiSelect for 'group by'
+      const msvars = found_vars
+        .map((name: string) =>
+          // We add a $ prefix to mark this as a prompt parameter, and so
+          // in the future we can add special types of variables without name collisions
+          ({ value: name, label: name }),
+        )
+        .concat({ value: "$LLM", label: "LLM" });
+      if (contains_eval_res && viewFormat === "table")
+        msvars.push({ value: "$EVAL_RES", label: "Eval results" });
+      setMultiSelectVars(msvars);
 
-    // Set the variables accessible in the MultiSelect for 'group by'
-    const msvars = found_vars
-      .map((name: string) =>
-        // We add a $ prefix to mark this as a prompt parameter, and so
-        // in the future we can add special types of variables without name collisions
-        ({ value: name, label: name }),
-      )
-      .concat({ value: "$LLM", label: "LLM" });
-    if (contains_eval_res && viewFormat === "table")
-      msvars.push({ value: "$EVAL_RES", label: "Eval results" });
-    setMultiSelectVars(msvars);
-
-    // If only one LLM is present, and user hasn't manually selected one to plot,
-    // and there's more than one prompt variable as input, default to plotting the
-    // eval scores, or the first found prompt variable as columns instead:
-    if (
-      viewFormat === "table" &&
-      !userSelectedTableCol &&
-      tableColVar === "$LLM"
-    ) {
+      // If only one LLM is present, and user hasn't manually selected one to plot,
+      // and there's more than one prompt variable as input, default to plotting the
+      // eval scores, or the first found prompt variable as columns instead:
       if (
-        contains_multi_evals ||
-        (found_llms.length === 1 && contains_eval_res)
+        viewFormat === "table" &&
+        !userSelectedTableCol &&
+        tableColVar === "$LLM"
       ) {
-        // Plot eval scores on columns
-        setTableColVar("$EVAL_RES");
-        return;
-      } else if (found_llms.length === 1 && found_vars.length > 1) {
-        setTableColVar(found_vars[0]);
+        if (
+          contains_multi_evals ||
+          (found_llms.length === 1 && contains_eval_res)
+        ) {
+          // Plot eval scores on columns
+          setTableColVar("$EVAL_RES");
+          return;
+        } else if (found_llms.length === 1 && found_vars.length > 1) {
+          setTableColVar(found_vars[0]);
+          return; // useEffect will replot with the new values
+        }
+      }
+
+      // If this is the first time receiving responses, set the multiSelectValue to whatever is the first:
+      if (!receivedResponsesOnce) {
+        if (contains_multi_evals)
+          // If multiple evals are detected, default to "table" format:
+          setViewFormat("table");
+        setMultiSelectValue([msvars[0].value]);
+        setReceivedResponsesOnce(true);
+      } else if (
+        multiSelectValue.some((name) => !msvars.some((o) => o.value === name))
+      ) {
+        // If the multi select vars changed and no longer includes the user's selected value,
+        // erase every value that went away, then early exit because useEffect is going to immediately recall this function:
+        setMultiSelectValue(
+          multiSelectValue.filter((name) => msvars.some((o) => o.value === name)),
+        );
         return; // useEffect will replot with the new values
       }
-    }
 
-    // If this is the first time receiving responses, set the multiSelectValue to whatever is the first:
-    if (!receivedResponsesOnce) {
-      if (contains_multi_evals)
-        // If multiple evals are detected, default to "table" format:
-        setViewFormat("table");
-      setMultiSelectValue([msvars[0].value]);
-      setReceivedResponsesOnce(true);
-    } else if (
-      multiSelectValue.some((name) => !msvars.some((o) => o.value === name))
-    ) {
-      // If the multi select vars changed and no longer includes the user's selected value,
-      // erase every value that went away, then early exit because useEffect is going to immediately recall this function:
-      setMultiSelectValue(
-        multiSelectValue.filter((name) => msvars.some((o) => o.value === name)),
-      );
-      return; // useEffect will replot with the new values
-    }
-
-    // Regroup responses by batch ID
-    let responses = batchedResponses;
-    let numResponsesDisplayed = 0;
-    const selected_vars = multiSelectValue;
-    const empty_cell_text = searchValue.length > 0 ? "(no match)" : "(no data)";
-    const search_regex = new RegExp(
-      escapeRegExp(searchValue),
-      caseSensitive ? "" : "i",
-    );
-
-    // Filter responses by search value, if user has searched
-    if (searchValue.length > 0 && filterBySearchValue)
-      responses = responses.filter((res_obj) =>
-        res_obj.responses.some(
-          (r) => (typeof r === "string" || typeof r === "number") && search_regex.test(StringLookup.get(r) ?? ""),
-        ),
+      // Regroup responses by batch ID
+      let responses = batchedResponses;
+      let numResponsesDisplayed = 0;
+      const selected_vars = multiSelectValue;
+      const empty_cell_text = searchValue.length > 0 ? "(no match)" : "(no data)";
+      const search_regex = new RegExp(
+        escapeRegExp(searchValue),
+        caseSensitive ? "" : "i",
       );
 
-    // Functions to associate a color to each LLM in responses
-    const color_for_llm = (llm: string) =>
-      getColorForLLMAndSetIfNotFound(llm) + "99";
-    const header_bg_colors = ["#e0f4fa", "#c0def9", "#a9c0f9", "#a6b2ea"];
-    const response_box_colors = [
-      "#eee",
-      "#fff",
-      "#eee",
-      "#ddd",
-      "#eee",
-      "#ddd",
-      "#eee",
-    ];
-    const rgroup_color = (depth: number) =>
-      response_box_colors[depth % response_box_colors.length];
-
-    const getHeaderBadge = (
-      key: string,
-      val: string | undefined,
-      depth: number,
-    ) => {
-      if (val !== undefined) {
-        const s = truncStr(val.trim(), 1024);
-        return (
-          <div
-            className="response-var-header"
-            style={{
-              backgroundColor:
-                header_bg_colors[depth % header_bg_colors.length],
-            }}
-          >
-            <span className="response-var-name">{key}&nbsp;=&nbsp;</span>
-            <span className="response-var-value">{`"${s}"`}</span>
-          </div>
-        );
-      } else {
-        return (
-          <div className="response-var-header">{`unspecified ${key}`}</div>
-        );
-      }
-    };
-
-    const generateResponseBoxes = (
-      resps: LLMResponse[],
-      eatenvars: string[],
-      fixed_width: number,
-      hide_eval_scores?: boolean,
-    ) => {
-      const hide_llm_name = eatenvars.includes("LLM");
-      return resps.map((res_obj, res_idx) => {
-        // If user has searched for something, further filter the response texts by only those that contain the search term
-        const respsFilterFunc = (responses: LLMResponseData[]) => {
-          if (searchValue.length === 0) return responses;
-          const filtered_resps = responses.filter(
+      // Filter responses by search value, if user has searched
+      if (searchValue.length > 0 && filterBySearchValue)
+        responses = responses.filter((res_obj) =>
+          res_obj.responses.some(
             (r) => (typeof r === "string" || typeof r === "number") && search_regex.test(StringLookup.get(r) ?? ""),
-          );
-          numResponsesDisplayed += filtered_resps.length;
-          if (filterBySearchValue) return filtered_resps;
-          else return responses;
-        };
-
-        const innerTextsDisplay = genResponseTextsDisplay(
-          res_obj,
-          respsFilterFunc,
-          (txt) =>
-            searchValue
-              ? genSpansForHighlightedValue(txt, searchValue, caseSensitive)
-              : txt,
-          contains_eval_res && onlyShowScores,
-          hide_llm_name ? undefined : getLLMName(res_obj),
-          wideFormat,
-          hide_eval_scores,
-        );
-
-        // At the deepest level, there may still be some vars left over. We want to display these
-        // as tags, too, so we need to display only the ones that weren't 'eaten' during the recursive call:
-        // (e.g., the vars that weren't part of the initial 'varnames' list that form the groupings)
-        const unused_vars = transformDict(
-          res_obj.vars,
-          (v) => !eatenvars.includes(v),
-        );
-        const llmName = getLLMName(res_obj);
-        return (
-          <ResponseBox
-            key={"r" + res_idx}
-            boxColor={color_for_llm(llmName)}
-            width={`${fixed_width}%`}
-            vars={unused_vars}
-            truncLenForVars={wideFormat ? 72 : 18}
-            llmName={hide_llm_name ? undefined : llmName}
-          >
-            {innerTextsDisplay}
-          </ResponseBox>
-        );
-      });
-    };
-
-    // Generate a view of the responses based on the view format set by the user
-    if (viewFormat === "table") {
-      // Generate a table, with default columns for: input vars, LLMs queried
-      // First get column names as input vars + LLMs:
-      let var_cols: string[],
-        colnames: string[],
-        getColVal: (r: LLMResponse) => string | number | undefined,
-        found_sel_var_vals: string[],
-        eval_res_cols: string[];
-      let metavar_cols: string[] = []; // found_metavars; -- Disabling this functionality for now, since it is usually annoying.
-      if (tableColVar === "$LLM") {
-        var_cols = found_vars;
-        getColVal = getLLMName;
-        found_sel_var_vals = found_llms;
-        colnames = var_cols.concat(metavar_cols).concat(found_llms);
-      } else {
-        metavar_cols = [];
-        var_cols = found_vars
-          .filter((v) => v !== tableColVar)
-          .concat(found_llms.length > 1 ? ["LLM"] : []); // only add LLM column if num LLMs > 1
-        getColVal = (r) => StringLookup.get(r.vars[tableColVar]) ?? "";
-        colnames = var_cols;
-        found_sel_var_vals = [];
-      }
-
-      // If the user wants to plot eval results in separate column, OR there's only a single LLM to show
-      if (tableColVar === "$EVAL_RES") {
-        // Plot evaluation results on separate column(s):
-        eval_res_cols = getEvalResCols(responses);
-        // if (tableColVar === "$EVAL_RES") {
-        // This adds a column, "Response", abusing the way getColVal and found_sel_var_vals is used
-        // below by making a dummy value (one giant group with all responses in it). We then
-        // sort the responses by LLM, to give a nicer view.
-        colnames = colnames.concat("Response", eval_res_cols);
-        getColVal = () => "_";
-        found_sel_var_vals = ["_"];
-        responses.sort((a, b) => getLLMName(a).localeCompare(getLLMName(b)));
-        // } else {
-        //   colnames = colnames.concat(eval_res_cols);
-        // }
-      } else if (tableColVar !== "$LLM") {
-        // Get the unique values for the selected variable
-        found_sel_var_vals = Array.from(
-          responses.reduce((acc, res_obj) => {
-            acc.add(
-              tableColVar in res_obj.vars
-                ? StringLookup.get(res_obj.vars[tableColVar]) ?? ""
-                : "(unspecified)",
-            );
-            return acc;
-          }, new Set<string>()),
-        );
-        colnames = colnames.concat(found_sel_var_vals.map(v => (StringLookup.get(v) ?? "(string lookup failed)")));
-      }
-
-      const getVar = (r: LLMResponse, v: string) =>
-        v === "LLM" ? getLLMName(r) : StringLookup.get(r.vars[v]) ?? "";
-
-      // Then group responses by prompts. Each prompt will become a separate row of the table (will be treated as unique)
-      const responses_by_prompt = groupResponsesBy(responses, (r) =>
-        var_cols.map((v) => getVar(r, v)).join("|"),
-      )[0];
-
-      const rows = Object.entries(responses_by_prompt).map(
-        // eslint-disable-next-line
-        ([prompt, resp_objs], idx) => {
-          // We assume here that prompt input vars will be the same across all responses in this bundle,
-          // so we just take the value of the first one per each varname:
-          const var_cols_vals = var_cols.map((v) => {
-            const val =
-              v === "LLM" ? getLLMName(resp_objs[0]) : resp_objs[0].vars[v];
-            return val !== undefined ? val : "(unspecified)";
-          });
-          const metavar_cols_vals = metavar_cols.map((v) => {
-            const val = resp_objs[0].metavars[v];
-            return val !== undefined ? val : "(unspecified)";
-          });
-          let eval_cols_vals: React.ReactNode[] = [];
-          if (eval_res_cols && eval_res_cols.length > 0) {
-            // We can assume that there's only one response object, since to
-            // if eval_res_cols is set, there must be only one LLM.
-            eval_cols_vals = eval_res_cols.map((metric_name, metric_idx) => {
-              const items = resp_objs[0].eval_res?.items;
-              if (!items) return "(no result)";
-              return items.map((item) => {
-                if (item === undefined) return "(undefined)";
-                if (
-                  typeof item !== "object" &&
-                  metric_idx === 0 &&
-                  metric_name === "Score"
-                )
-                  return getEvalResultStr(item, true);
-                else if (typeof item === "object" && metric_name in item)
-                  return getEvalResultStr(item[metric_name], true);
-                else return "(unspecified)";
-              }); // treat n>1 resps per prompt as multi-line results in the column
-            });
-          }
-          const resp_objs_by_col_var = groupResponsesBy(
-            resp_objs,
-            getColVal,
-          )[0];
-          const sel_var_cols = found_sel_var_vals.map((val, idx) => {
-            if (val in resp_objs_by_col_var) {
-              const rs = resp_objs_by_col_var[val];
-              // Return response divs as response box here:
-              return (
-                <div key={idx}>
-                  {generateResponseBoxes(
-                    rs,
-                    var_cols,
-                    100,
-                    eval_res_cols !== undefined,
-                  )}
-                </div>
-              );
-            } else {
-              return <i key={idx}>{empty_cell_text}</i>;
-            }
-          });
-
-          return (
-            <tr key={`r${idx}`} style={{ borderBottom: "2px solid #fff" }}>
-              {var_cols_vals.map((c, i) => (
-                <td key={`v${i}`} className="inspect-table-var">
-                  <ScrollArea.Autosize mt="sm" mah={500} maw={300}>
-                    {StringLookup.get(c)}
-                  </ScrollArea.Autosize>
-                </td>
-              ))}
-              {metavar_cols_vals.map((c, i) => (
-                <td key={`m${i}`} className="inspect-table-metavar">
-                  {StringLookup.get(c)}
-                </td>
-              ))}
-              {sel_var_cols.map((c, i) => (
-                <td key={`c${i}`} className="inspect-table-llm-resp">
-                  {StringLookup.get(c)}
-                </td>
-              ))}
-              {eval_cols_vals.map((c, i) => (
-                <td key={`e${i}`} className="inspect-table-score-col">
-                  <Stack spacing={0}>{c}</Stack>
-                </td>
-              ))}
-            </tr>
-          );
-        },
-      );
-
-      setResponseDivs([
-        <Table
-          key="table"
-          fontSize={wideFormat ? "sm" : "xs"}
-          horizontalSpacing="xs"
-          verticalSpacing={0}
-          striped
-          withColumnBorders={true}
-        >
-          <thead>
-            <tr>
-              {colnames.map((c) => (
-                <th key={c}>{c}</th>
-              ))}
-            </tr>
-          </thead>
-          <tbody style={{ verticalAlign: "top" }}>{rows}</tbody>
-        </Table>,
-      ]);
-    } else if (viewFormat === "hierarchy") {
-      // Now we need to perform groupings by each var in the selected vars list,
-      // nesting the groupings (preferrably with custom divs) and sorting within
-      // each group by value of that group's var (so all same values are clumped together).
-      // :: For instance, for varnames = ['LLM', '$var1', '$var2'] we should get back
-      // :: nested divs first grouped by LLM (first level), then by var1, then var2 (deepest level).
-      let leaf_id = 0;
-      let first_opened = false;
-      const groupByVars = (
-        resps: LLMResponse[],
-        varnames: string[],
-        eatenvars: string[],
-        header: React.ReactNode,
-      ): React.ReactNode => {
-        if (resps.length === 0) return [];
-        if (varnames.length === 0) {
-          // Base case. Display n response(s) to each single prompt, back-to-back:
-          let fixed_width = 100;
-          const side_by_side_resps = wideFormat;
-          if (side_by_side_resps && eatenvars.length > 0) {
-            const num_llms = Array.from(new Set(resps.map(getLLMName))).length;
-            fixed_width = Math.max(20, Math.trunc(100 / num_llms)) - 1; // 20% width is lowest we will go (5 LLM response boxes max)
-          }
-          const resp_boxes = generateResponseBoxes(
-            resps,
-            eatenvars,
-            fixed_width,
-          );
-          const className = eatenvars.length > 0 ? "response-group" : "";
-          const boxesClassName =
-            eatenvars.length > 0 ? "response-boxes-wrapper" : "";
-          const flexbox =
-            side_by_side_resps && fixed_width < 100 ? "flex" : "block";
-          const defaultOpened =
-            !first_opened ||
-            eatenvars.length === 0 ||
-            eatenvars[eatenvars.length - 1] === "$LLM";
-          first_opened = true;
-          leaf_id += 1;
-          return (
-            <div
-              key={"l" + leaf_id}
-              className={className}
-              style={{ backgroundColor: rgroup_color(eatenvars.length) }}
-            >
-              <ResponseGroup
-                header={header}
-                responseBoxes={resp_boxes}
-                responseBoxesWrapperClass={boxesClassName}
-                displayStyle={flexbox}
-                defaultState={defaultOpened}
-              />
-            </div>
-          );
-        }
-
-        // Bucket responses by the first var in the list, where
-        // we also bucket any 'leftover' responses that didn't have the requested variable (a kind of 'soft fail')
-        const group_name = varnames[0];
-        const [grouped_resps, leftover_resps] =
-          group_name === "$LLM"
-            ? groupResponsesBy(resps, getLLMName)
-            : groupResponsesBy(resps, (r) =>
-                group_name in r.vars ? StringLookup.get(r.vars[group_name]) : null,
-              );
-        const get_header =
-          group_name === "$LLM"
-            ? (key: string, val?: string) => (
-                <div
-                  key={val}
-                  style={{ backgroundColor: val ? color_for_llm(val) : "#eee" }}
-                  className="response-llm-header"
-                >
-                  {val}
-                </div>
-              )
-            : (key: string, val?: string) =>
-                getHeaderBadge(key, val, eatenvars.length);
-
-        // Now produce nested divs corresponding to the groups
-        const remaining_vars = varnames.slice(1);
-        const updated_eatenvars = eatenvars.concat([group_name]);
-        const defaultOpened =
-          !first_opened ||
-          eatenvars.length === 0 ||
-          eatenvars[eatenvars.length - 1] === "$LLM";
-        const grouped_resps_divs = Object.keys(grouped_resps).map((g) =>
-          groupByVars(
-            grouped_resps[g],
-            remaining_vars,
-            updated_eatenvars,
-            get_header(group_name, g),
           ),
         );
-        const leftover_resps_divs =
-          leftover_resps.length > 0
-            ? groupByVars(
-                leftover_resps,
-                remaining_vars,
-                updated_eatenvars,
-                get_header(group_name, undefined),
-              )
-            : [];
 
-        leaf_id += 1;
+      // Functions to associate a color to each LLM in responses
+      const color_for_llm = (llm: string) =>
+        getColorForLLMAndSetIfNotFound(llm) + "99";
+      const header_bg_colors = ["#e0f4fa", "#c0def9", "#a9c0f9", "#a6b2ea"];
+      const response_box_colors = [
+        "#eee",
+        "#fff",
+        "#eee",
+        "#ddd",
+        "#eee",
+        "#ddd",
+        "#eee",
+      ];
+      const rgroup_color = (depth: number) =>
+        response_box_colors[depth % response_box_colors.length];
 
-        return (
-          <div key={"h" + group_name + "_" + leaf_id}>
-            {header ? (
+      const getHeaderBadge = (
+        key: string,
+        val: string | undefined,
+        depth: number,
+      ) => {
+        if (val !== undefined) {
+          const s = truncStr(val.trim(), 1024);
+          return (
+            <div
+              className="response-var-header"
+              style={{
+                backgroundColor:
+                  header_bg_colors[depth % header_bg_colors.length],
+              }}
+            >
+              <span className="response-var-name">{key}&nbsp;=&nbsp;</span>
+              <span className="response-var-value">{`"${s}"`}</span>
+            </div>
+          );
+        } else {
+          return (
+            <div className="response-var-header">{`unspecified ${key}`}</div>
+          );
+        }
+      };
+
+      const generateResponseBoxes = (
+        resps: LLMResponse[],
+        eatenvars: string[],
+        fixed_width: number,
+        hide_eval_scores?: boolean,
+      ) => {
+        const hide_llm_name = eatenvars.includes("LLM");
+        return resps.map((res_obj, res_idx) => {
+          // If user has searched for something, further filter the response texts by only those that contain the search term
+          const respsFilterFunc = (responses: LLMResponseData[]) => {
+            if (searchValue.length === 0) return responses;
+            const filtered_resps = responses.filter(
+              (r) => (typeof r === "string" || typeof r === "number") && search_regex.test(StringLookup.get(r) ?? ""),
+            );
+            numResponsesDisplayed += filtered_resps.length;
+            if (filterBySearchValue) return filtered_resps;
+            else return responses;
+          };
+
+          const innerTextsDisplay = genResponseTextsDisplay(
+            res_obj,
+            respsFilterFunc,
+            (txt) =>
+              searchValue
+                ? genSpansForHighlightedValue(txt, searchValue, caseSensitive)
+                : txt,
+            contains_eval_res && onlyShowScores,
+            hide_llm_name ? undefined : getLLMName(res_obj),
+            wideFormat,
+            hide_eval_scores,
+          );
+
+          // At the deepest level, there may still be some vars left over. We want to display these
+          // as tags, too, so we need to display only the ones that weren't 'eaten' during the recursive call:
+          // (e.g., the vars that weren't part of the initial 'varnames' list that form the groupings)
+          const unused_vars = transformDict(
+            res_obj.vars,
+            (v) => !eatenvars.includes(v),
+          );
+          const llmName = getLLMName(res_obj);
+          return (
+            <ResponseBox
+              key={"r" + res_idx}
+              boxColor={color_for_llm(llmName)}
+              width={`${fixed_width}%`}
+              vars={unused_vars}
+              truncLenForVars={wideFormat ? 72 : 18}
+              llmName={hide_llm_name ? undefined : llmName}
+            >
+              {innerTextsDisplay}
+            </ResponseBox>
+          );
+        });
+      };
+
+      // Generate a view of the responses based on the view format set by the user
+      if (viewFormat === "table") {
+        // Generate a table, with default columns for: input vars, LLMs queried
+        // First get column names as input vars + LLMs:
+        let var_cols: string[],
+          colnames: string[],
+          getColVal: (r: LLMResponse) => string | number | undefined,
+          found_sel_var_vals: string[],
+          eval_res_cols: string[];
+        let metavar_cols: string[] = []; // found_metavars; -- Disabling this functionality for now, since it is usually annoying.
+        if (tableColVar === "$LLM") {
+          var_cols = found_vars;
+          getColVal = getLLMName;
+          found_sel_var_vals = found_llms;
+          colnames = var_cols.concat(metavar_cols).concat(found_llms);
+        } else {
+          metavar_cols = [];
+          var_cols = found_vars
+            .filter((v) => v !== tableColVar)
+            .concat(found_llms.length > 1 ? ["LLM"] : []); // only add LLM column if num LLMs > 1
+          getColVal = (r) => StringLookup.get(r.vars[tableColVar]) ?? "";
+          colnames = var_cols;
+          found_sel_var_vals = [];
+        }
+
+        // If the user wants to plot eval results in separate column, OR there's only a single LLM to show
+        if (tableColVar === "$EVAL_RES") {
+          // Plot evaluation results on separate column(s):
+          eval_res_cols = getEvalResCols(responses);
+          // if (tableColVar === "$EVAL_RES") {
+          // This adds a column, "Response", abusing the way getColVal and found_sel_var_vals is used
+          // below by making a dummy value (one giant group with all responses in it). We then
+          // sort the responses by LLM, to give a nicer view.
+          colnames = colnames.concat("Response", eval_res_cols);
+          getColVal = () => "_";
+          found_sel_var_vals = ["_"];
+          responses.sort((a, b) => getLLMName(a).localeCompare(getLLMName(b)));
+          // } else {
+          //   colnames = colnames.concat(eval_res_cols);
+          // }
+        } else if (tableColVar !== "$LLM") {
+          // Get the unique values for the selected variable
+          found_sel_var_vals = Array.from(
+            responses.reduce((acc, res_obj) => {
+              acc.add(
+                tableColVar in res_obj.vars
+                  ? StringLookup.get(res_obj.vars[tableColVar]) ?? ""
+                  : "(unspecified)",
+              );
+              return acc;
+            }, new Set<string>()),
+          );
+          colnames = colnames.concat(found_sel_var_vals.map(v => (StringLookup.get(v) ?? "(string lookup failed)")));
+        }
+
+        const getVar = (r: LLMResponse, v: string) =>
+          v === "LLM" ? getLLMName(r) : StringLookup.get(r.vars[v]) ?? "";
+
+        // Then group responses by prompts. Each prompt will become a separate row of the table (will be treated as unique)
+        const responses_by_prompt = groupResponsesBy(responses, (r) =>
+          var_cols.map((v) => getVar(r, v)).join("|"),
+        )[0];
+
+        const rows = Object.entries(responses_by_prompt).map(
+          // eslint-disable-next-line
+          ([prompt, resp_objs], idx) => {
+            // We assume here that prompt input vars will be the same across all responses in this bundle,
+            // so we just take the value of the first one per each varname:
+            const var_cols_vals = var_cols.map((v) => {
+              const val =
+                v === "LLM" ? getLLMName(resp_objs[0]) : resp_objs[0].vars[v];
+              return val !== undefined ? val : "(unspecified)";
+            });
+            const metavar_cols_vals = metavar_cols.map((v) => {
+              const val = resp_objs[0].metavars[v];
+              return val !== undefined ? val : "(unspecified)";
+            });
+            let eval_cols_vals: React.ReactNode[] = [];
+            if (eval_res_cols && eval_res_cols.length > 0) {
+              // We can assume that there's only one response object, since to
+              // if eval_res_cols is set, there must be only one LLM.
+              eval_cols_vals = eval_res_cols.map((metric_name, metric_idx) => {
+                const items = resp_objs[0].eval_res?.items;
+                if (!items) return "(no result)";
+                return items.map((item) => {
+                  if (item === undefined) return "(undefined)";
+                  if (
+                    typeof item !== "object" &&
+                    metric_idx === 0 &&
+                    metric_name === "Score"
+                  )
+                    return getEvalResultStr(item, true);
+                  else if (typeof item === "object" && metric_name in item)
+                    return getEvalResultStr(item[metric_name], true);
+                  else return "(unspecified)";
+                }); // treat n>1 resps per prompt as multi-line results in the column
+              });
+            }
+            const resp_objs_by_col_var = groupResponsesBy(
+              resp_objs,
+              getColVal,
+            )[0];
+            const sel_var_cols = found_sel_var_vals.map((val, idx) => {
+              if (val in resp_objs_by_col_var) {
+                const rs = resp_objs_by_col_var[val];
+                // Return response divs as response box here:
+                return (
+                  <div key={idx}>
+                    {generateResponseBoxes(
+                      rs,
+                      var_cols,
+                      100,
+                      eval_res_cols !== undefined,
+                    )}
+                  </div>
+                );
+              } else {
+                return <i key={idx}>{empty_cell_text}</i>;
+              }
+            });
+
+            return (
+              <tr key={`r${idx}`} style={{ borderBottom: "2px solid #fff" }}>
+                {var_cols_vals.map((c, i) => (
+                  <td key={`v${i}`} className="inspect-table-var">
+                    <ScrollArea.Autosize mt="sm" mah={500} maw={300}>
+                      {StringLookup.get(c)}
+                    </ScrollArea.Autosize>
+                  </td>
+                ))}
+                {metavar_cols_vals.map((c, i) => (
+                  <td key={`m${i}`} className="inspect-table-metavar">
+                    {StringLookup.get(c)}
+                  </td>
+                ))}
+                {sel_var_cols.map((c, i) => (
+                  <td key={`c${i}`} className="inspect-table-llm-resp">
+                    {StringLookup.get(c)}
+                  </td>
+                ))}
+                {eval_cols_vals.map((c, i) => (
+                  <td key={`e${i}`} className="inspect-table-score-col">
+                    <Stack spacing={0}>{c}</Stack>
+                  </td>
+                ))}
+              </tr>
+            );
+          },
+        );
+
+        setResponseDivs([
+          <Table
+            key="table"
+            fontSize={wideFormat ? "sm" : "xs"}
+            horizontalSpacing="xs"
+            verticalSpacing={0}
+            striped
+            withColumnBorders={true}
+          >
+            <thead>
+              <tr>
+                {colnames.map((c) => (
+                  <th key={c}>{c}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody style={{ verticalAlign: "top" }}>{rows}</tbody>
+          </Table>,
+        ]);
+      } else if (viewFormat === "hierarchy") {
+        // Now we need to perform groupings by each var in the selected vars list,
+        // nesting the groupings (preferrably with custom divs) and sorting within
+        // each group by value of that group's var (so all same values are clumped together).
+        // :: For instance, for varnames = ['LLM', '$var1', '$var2'] we should get back
+        // :: nested divs first grouped by LLM (first level), then by var1, then var2 (deepest level).
+        let leaf_id = 0;
+        let first_opened = false;
+        const groupByVars = (
+          resps: LLMResponse[],
+          varnames: string[],
+          eatenvars: string[],
+          header: React.ReactNode,
+        ): React.ReactNode => {
+          if (resps.length === 0) return [];
+          if (varnames.length === 0) {
+            // Base case. Display n response(s) to each single prompt, back-to-back:
+            let fixed_width = 100;
+            const side_by_side_resps = wideFormat;
+            if (side_by_side_resps && eatenvars.length > 0) {
+              const num_llms = Array.from(new Set(resps.map(getLLMName))).length;
+              fixed_width = Math.max(20, Math.trunc(100 / num_llms)) - 1; // 20% width is lowest we will go (5 LLM response boxes max)
+            }
+            const resp_boxes = generateResponseBoxes(
+              resps,
+              eatenvars,
+              fixed_width,
+            );
+            const className = eatenvars.length > 0 ? "response-group" : "";
+            const boxesClassName =
+              eatenvars.length > 0 ? "response-boxes-wrapper" : "";
+            const flexbox =
+              side_by_side_resps && fixed_width < 100 ? "flex" : "block";
+            const defaultOpened =
+              !first_opened ||
+              eatenvars.length === 0 ||
+              eatenvars[eatenvars.length - 1] === "$LLM";
+            first_opened = true;
+            leaf_id += 1;
+            return (
               <div
-                key={group_name}
-                className="response-group"
+                key={"l" + leaf_id}
+                className={className}
                 style={{ backgroundColor: rgroup_color(eatenvars.length) }}
               >
                 <ResponseGroup
                   header={header}
-                  responseBoxes={grouped_resps_divs}
-                  responseBoxesWrapperClass="response-boxes-wrapper"
-                  displayStyle="block"
+                  responseBoxes={resp_boxes}
+                  responseBoxesWrapperClass={boxesClassName}
+                  displayStyle={flexbox}
                   defaultState={defaultOpened}
                 />
               </div>
-            ) : (
-              <div key={group_name}>{grouped_resps_divs}</div>
-            )}
-            {Array.isArray(leftover_resps_divs) &&
-            leftover_resps_divs.length === 0 ? (
-              <></>
-            ) : (
-              <div key={"__unspecified_group"} className="response-group">
-                {leftover_resps_divs}
-              </div>
-            )}
-          </div>
-        );
-      };
+            );
+          }
 
-      // Produce DIV elements grouped by selected vars
-      const divs = groupByVars(responses, selected_vars, [], null);
-      setResponseDivs(divs);
-    }
+          // Bucket responses by the first var in the list, where
+          // we also bucket any 'leftover' responses that didn't have the requested variable (a kind of 'soft fail')
+          const group_name = varnames[0];
+          const [grouped_resps, leftover_resps] =
+            group_name === "$LLM"
+              ? groupResponsesBy(resps, getLLMName)
+              : groupResponsesBy(resps, (r) =>
+                  group_name in r.vars ? StringLookup.get(r.vars[group_name]) : null,
+                );
+          const get_header =
+            group_name === "$LLM"
+              ? (key: string, val?: string) => (
+                  <div
+                    key={val}
+                    style={{ backgroundColor: val ? color_for_llm(val) : "#eee" }}
+                    className="response-llm-header"
+                  >
+                    {val}
+                  </div>
+                )
+              : (key: string, val?: string) =>
+                  getHeaderBadge(key, val, eatenvars.length);
 
-    setNumMatches(numResponsesDisplayed);
+          // Now produce nested divs corresponding to the groups
+          const remaining_vars = varnames.slice(1);
+          const updated_eatenvars = eatenvars.concat([group_name]);
+          const defaultOpened =
+            !first_opened ||
+            eatenvars.length === 0 ||
+            eatenvars[eatenvars.length - 1] === "$LLM";
+          const grouped_resps_divs = Object.keys(grouped_resps).map((g) =>
+            groupByVars(
+              grouped_resps[g],
+              remaining_vars,
+              updated_eatenvars,
+              get_header(group_name, g),
+            ),
+          );
+          const leftover_resps_divs =
+            leftover_resps.length > 0
+              ? groupByVars(
+                  leftover_resps,
+                  remaining_vars,
+                  updated_eatenvars,
+                  get_header(group_name, undefined),
+                )
+              : [];
+
+          leaf_id += 1;
+
+          return (
+            <div key={"h" + group_name + "_" + leaf_id}>
+              {header ? (
+                <div
+                  key={group_name}
+                  className="response-group"
+                  style={{ backgroundColor: rgroup_color(eatenvars.length) }}
+                >
+                  <ResponseGroup
+                    header={header}
+                    responseBoxes={grouped_resps_divs}
+                    responseBoxesWrapperClass="response-boxes-wrapper"
+                    displayStyle="block"
+                    defaultState={defaultOpened}
+                  />
+                </div>
+              ) : (
+                <div key={group_name}>{grouped_resps_divs}</div>
+              )}
+              {Array.isArray(leftover_resps_divs) &&
+              leftover_resps_divs.length === 0 ? (
+                <></>
+              ) : (
+                <div key={"__unspecified_group"} className="response-group">
+                  {leftover_resps_divs}
+                </div>
+              )}
+            </div>
+          );
+        };
+
+        // Produce DIV elements grouped by selected vars
+        const divs = groupByVars(responses, selected_vars, [], null);
+        setResponseDivs(divs);
+      }
+
+      setNumMatches(numResponsesDisplayed);
+    });
   };
 
   // Trigger a redraw of the inspector when any of the below changes:
-  useEffect(triggerRedraw, [
+  useEffect(() => {
+    // Trigger redraw, but debounce to avoid too-quick re-renders
+    debounce(triggerRedraw, 30)();
+  }, [
     multiSelectValue,
     batchedResponses,
     wideFormat,
@@ -997,7 +1031,11 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
         </Tabs.Panel>
       </Tabs>
 
-      <div className="nowheel nodrag">{responseDivs}</div>
+      <div className="nowheel nodrag">
+        {/* To get the overlay to operate just inside the div, use style={{position: "relative"}}. However it won't show the spinner in the right place. */}
+        <LoadingOverlay visible={showLoadingSpinner} overlayOpacity={0.5} />
+        {responseDivs}
+      </div>
     </div>
   );
 };

--- a/chainforge/react-server/src/LLMResponseInspector.tsx
+++ b/chainforge/react-server/src/LLMResponseInspector.tsx
@@ -957,7 +957,9 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
     <div style={{ height: "100%" }}>
       <Tabs
         value={viewFormat}
-        onTabChange={(val) => setViewFormat(val ?? "hierarchy")}
+        onTabChange={(val) => {
+          setViewFormat(val ?? "hierarchy");
+        }}
         styles={{ tabLabel: { fontSize: wideFormat ? "12pt" : "9pt" } }}
       >
         <Tabs.List>

--- a/chainforge/react-server/src/PromptNode.tsx
+++ b/chainforge/react-server/src/PromptNode.tsx
@@ -952,7 +952,12 @@ Soft failing by replacing undefined with empty strings.`,
                 resp_obj.responses.map((r) => {
                   // Carry over the response text, prompt, prompt fill history (vars), and llm nickname:
                   const o: TemplateVarInfo = {
-                    text: typeof r === "number" ? escapeBraces(StringLookup.get(r)!) : ((typeof r === "string") ? escapeBraces(r) : undefined),
+                    text:
+                      typeof r === "number"
+                        ? escapeBraces(StringLookup.get(r)!)
+                        : typeof r === "string"
+                          ? escapeBraces(r)
+                          : undefined,
                     image:
                       typeof r === "object" && r.t === "img" ? r.d : undefined,
                     prompt: resp_obj.prompt,
@@ -963,7 +968,10 @@ Soft failing by replacing undefined with empty strings.`,
                     uid: resp_obj.uid,
                   };
 
-                  o.text = o.text !== undefined ? StringLookup.intern(o.text as string) : undefined;
+                  o.text =
+                    o.text !== undefined
+                      ? StringLookup.intern(o.text as string)
+                      : undefined;
 
                   // Carry over any metavars
                   o.metavars = resp_obj.metavars ?? {};
@@ -981,7 +989,7 @@ Soft failing by replacing undefined with empty strings.`,
                     typeof resp_obj.llm === "number"
                       ? StringLookup.get(resp_obj.llm) ?? "(LLM lookup failed)"
                       : resp_obj.llm.name;
-                  
+
                   console.log(o);
                   return o;
                 }),

--- a/chainforge/react-server/src/PromptNode.tsx
+++ b/chainforge/react-server/src/PromptNode.tsx
@@ -990,7 +990,6 @@ Soft failing by replacing undefined with empty strings.`,
                       ? StringLookup.get(resp_obj.llm) ?? "(LLM lookup failed)"
                       : resp_obj.llm.name;
 
-                  console.log(o);
                   return o;
                 }),
               )

--- a/chainforge/react-server/src/PromptNode.tsx
+++ b/chainforge/react-server/src/PromptNode.tsx
@@ -487,7 +487,7 @@ const PromptNode: React.FC<PromptNodeProps> = ({
       (info: TemplateVarInfo) => {
         // Add to unique LLMs list, if necessary
         if (
-          typeof info?.llm !== "string" &&
+          (typeof info?.llm !== "string" && typeof info?.llm !== "number") &&
           info?.llm?.name !== undefined &&
           !llm_names.has(info.llm.name)
         ) {
@@ -508,7 +508,7 @@ const PromptNode: React.FC<PromptNodeProps> = ({
 
         // Append any present system message retroactively as the first message in the chat history:
         if (
-          typeof info?.llm !== "string" &&
+          (typeof info?.llm !== "string" && typeof info?.llm !== "number") &&
           typeof info?.llm?.settings?.system_msg === "string" &&
           updated_chat_hist[0].role !== "system"
         )
@@ -521,7 +521,7 @@ const PromptNode: React.FC<PromptNodeProps> = ({
           messages: updated_chat_hist,
           fill_history: info.fill_history ?? {},
           metavars: info.metavars ?? {},
-          llm: typeof info?.llm === "string" ? info.llm : info?.llm?.name,
+          llm: (typeof info?.llm === "string" || typeof info?.llm === "number") ? (StringLookup.get(info.llm) ?? "(LLM lookup failed)") : info?.llm?.name,
           uid: uuid(),
         };
       },
@@ -969,8 +969,8 @@ Soft failing by replacing undefined with empty strings.`,
 
                   // Add a meta var to keep track of which LLM produced this response
                   o.metavars[llm_metavar_key] =
-                    typeof resp_obj.llm === "string"
-                      ? resp_obj.llm
+                    (typeof resp_obj.llm === "string" || typeof resp_obj.llm === "number")
+                      ? (StringLookup.get(resp_obj.llm) ?? "(LLM lookup failed)")
                       : resp_obj.llm.name;
                   return o;
                 }),

--- a/chainforge/react-server/src/PromptNode.tsx
+++ b/chainforge/react-server/src/PromptNode.tsx
@@ -62,6 +62,7 @@ import {
   grabResponses,
   queryLLM,
 } from "./backend/backend";
+import { StringLookup } from "./backend/cache";
 
 const getUniqueLLMMetavarKey = (responses: LLMResponse[]) => {
   const metakeys = new Set(
@@ -497,8 +498,8 @@ const PromptNode: React.FC<PromptNodeProps> = ({
         // Create revised chat_history on the TemplateVarInfo object,
         // with the prompt and text of the pulled data as the 2nd-to-last, and last, messages:
         const last_messages = [
-          { role: "user", content: info.prompt ?? "" },
-          { role: "assistant", content: info.text ?? "" },
+          { role: "user", content: StringLookup.get(info.prompt) ?? "" },
+          { role: "assistant", content: StringLookup.get(info.text) ?? "" },
         ];
         let updated_chat_hist =
           info.chat_history !== undefined

--- a/chainforge/react-server/src/PromptNode.tsx
+++ b/chainforge/react-server/src/PromptNode.tsx
@@ -52,6 +52,7 @@ import {
   QueryProgress,
   LLMResponse,
   TemplateVarInfo,
+  StringOrHash,
 } from "./backend/typing";
 import { AlertModalContext } from "./AlertModal";
 import { Status } from "./StatusIndicatorComponent";
@@ -540,7 +541,7 @@ const PromptNode: React.FC<PromptNodeProps> = ({
   const fetchResponseCounts = (
     prompt: string,
     vars: Dict,
-    llms: (string | Dict)[],
+    llms: (StringOrHash | LLMSpec)[],
     chat_histories?:
       | (ChatHistoryInfo | undefined)[]
       | Dict<(ChatHistoryInfo | undefined)[]>,

--- a/chainforge/react-server/src/ResponseBoxes.tsx
+++ b/chainforge/react-server/src/ResponseBoxes.tsx
@@ -20,22 +20,28 @@ const FAILURE_EVAL_SCORES = new Set(["false", "no"]);
 export const getEvalResultStr = (
   eval_item: EvaluationScore,
   hide_prefix: boolean,
-) => {
+  onlyString?: boolean,
+): JSX.Element | string => {
   if (Array.isArray(eval_item)) {
     return (hide_prefix ? "" : "scores: ") + eval_item.join(", ");
   } else if (typeof eval_item === "object") {
-    const strs = Object.keys(eval_item).map((key, j) => {
-      let val = eval_item[key];
-      if (typeof val === "number" && val.toString().indexOf(".") > -1)
-        val = val.toFixed(4); // truncate floats to 4 decimal places
-      return (
-        <div key={`${key}-${j}`}>
-          <span>{key}: </span>
-          <span>{getEvalResultStr(val, true)}</span>
-        </div>
-      );
-    });
-    return <Stack spacing={0}>{strs}</Stack>;
+    const strs: (JSX.Element | string)[] = Object.keys(eval_item).map(
+      (key, j) => {
+        let val = eval_item[key];
+        if (typeof val === "number" && val.toString().indexOf(".") > -1)
+          val = val.toFixed(4); // truncate floats to 4 decimal places
+        if (onlyString) return `${key}: ${getEvalResultStr(val, true, true)}`;
+        else
+          return (
+            <div key={`${key}-${j}`}>
+              <span>{key}: </span>
+              <span>{getEvalResultStr(val, true)}</span>
+            </div>
+          );
+      },
+    );
+    if (onlyString) return strs.join("\n");
+    else return <Stack spacing={0}>{strs}</Stack>;
   } else {
     const eval_str = eval_item.toString().trim().toLowerCase();
     const color = SUCCESS_EVAL_SCORES.has(eval_str)
@@ -43,12 +49,14 @@ export const getEvalResultStr = (
       : FAILURE_EVAL_SCORES.has(eval_str)
         ? "red"
         : "black";
-    return (
-      <>
-        {!hide_prefix && <span style={{ color: "gray" }}>{"score: "}</span>}
-        <span style={{ color }}>{eval_str}</span>
-      </>
-    );
+    if (onlyString) return `score: ${eval_str}`;
+    else
+      return (
+        <>
+          {!hide_prefix && <span style={{ color: "gray" }}>{"score: "}</span>}
+          <span style={{ color }}>{eval_str}</span>
+        </>
+      );
   }
 };
 

--- a/chainforge/react-server/src/ResponseBoxes.tsx
+++ b/chainforge/react-server/src/ResponseBoxes.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useMemo, lazy } from "react";
 import { Collapse, Flex, Stack } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { truncStr } from "./backend/utils";
+import { llmResponseDataToString, truncStr } from "./backend/utils";
 import {
   Dict,
   EvaluationScore,
@@ -133,7 +133,10 @@ export const ResponseBox: React.FC<ResponseBoxProps> = ({
   const var_tags = useMemo(() => {
     if (vars === undefined) return [];
     return Object.entries(vars).map(([varname, val]) => {
-      const v = truncStr((StringLookup.get(val) ?? "").trim(), truncLenForVars ?? 18);
+      const v = truncStr(
+        (StringLookup.get(val) ?? "").trim(),
+        truncLenForVars ?? 18,
+      );
       return (
         <div key={varname} className="response-var-inline">
           <span className="response-var-name">{varname}&nbsp;=&nbsp;</span>
@@ -193,16 +196,18 @@ export const genResponseTextsDisplay = (
   const resp_str_to_eval_res: Dict<EvaluationScore> = {};
   if (eval_res_items)
     responses.forEach((r, idx) => {
-      resp_str_to_eval_res[(typeof r === "string" || typeof r === "number") ? (StringLookup.get(r) ?? "") : r.d] =
-        eval_res_items[idx];
+      resp_str_to_eval_res[
+        llmResponseDataToString(r)
+      ] = eval_res_items[idx];
     });
 
   const same_resp_text_counts = countResponsesBy(responses, (r) =>
-    (typeof r === "string" || typeof r === "number") ? (StringLookup.get(r) ?? "") : r.d,
+    llmResponseDataToString(r),
   );
   const resp_special_type_map: Dict<string> = {};
   responses.forEach((r) => {
-    const key = (typeof r === "string" || typeof r === "number") ? (StringLookup.get(r) ?? "") : r.d;
+    const key =
+      llmResponseDataToString(r);
     if (typeof r === "object") resp_special_type_map[key] = r.t;
   });
   const same_resp_keys = Object.keys(same_resp_text_counts).sort(

--- a/chainforge/react-server/src/ResponseBoxes.tsx
+++ b/chainforge/react-server/src/ResponseBoxes.tsx
@@ -196,9 +196,7 @@ export const genResponseTextsDisplay = (
   const resp_str_to_eval_res: Dict<EvaluationScore> = {};
   if (eval_res_items)
     responses.forEach((r, idx) => {
-      resp_str_to_eval_res[
-        llmResponseDataToString(r)
-      ] = eval_res_items[idx];
+      resp_str_to_eval_res[llmResponseDataToString(r)] = eval_res_items[idx];
     });
 
   const same_resp_text_counts = countResponsesBy(responses, (r) =>
@@ -206,8 +204,7 @@ export const genResponseTextsDisplay = (
   );
   const resp_special_type_map: Dict<string> = {};
   responses.forEach((r) => {
-    const key =
-      llmResponseDataToString(r);
+    const key = llmResponseDataToString(r);
     if (typeof r === "object") resp_special_type_map[key] = r.t;
   });
   const same_resp_keys = Object.keys(same_resp_text_counts).sort(

--- a/chainforge/react-server/src/SplitNode.tsx
+++ b/chainforge/react-server/src/SplitNode.tsx
@@ -130,7 +130,9 @@ const displaySplitTexts = (
     } else {
       const llm_color =
         typeof info.llm === "object" && "name" in info.llm
-          ? color_for_llm(StringLookup.get(info.llm?.name) ?? "(string lookup failed)")
+          ? color_for_llm(
+              StringLookup.get(info.llm?.name) ?? "(string lookup failed)",
+            )
           : "#ddd";
       const llm_name =
         typeof info.llm === "object" && "name" in info.llm

--- a/chainforge/react-server/src/SplitNode.tsx
+++ b/chainforge/react-server/src/SplitNode.tsx
@@ -130,11 +130,11 @@ const displaySplitTexts = (
     } else {
       const llm_color =
         typeof info.llm === "object" && "name" in info.llm
-          ? color_for_llm(info.llm?.name)
+          ? color_for_llm(StringLookup.get(info.llm?.name) ?? "(string lookup failed)")
           : "#ddd";
       const llm_name =
         typeof info.llm === "object" && "name" in info.llm
-          ? info.llm?.name
+          ? StringLookup.get(info.llm?.name)
           : "";
       return (
         <ResponseBox
@@ -289,7 +289,11 @@ const SplitNode: React.FC<SplitNodeProps> = ({ data, id }) => {
           .map((resp_obj: TemplateVarInfo | string) => {
             if (typeof resp_obj === "string")
               return splitText(resp_obj, formatting, true);
-            const texts = splitText(StringLookup.get(resp_obj?.text) ?? "", formatting, true);
+            const texts = splitText(
+              StringLookup.get(resp_obj?.text) ?? "",
+              formatting,
+              true,
+            );
             if (texts !== undefined && texts.length >= 1)
               return texts.map(
                 (t: string) =>

--- a/chainforge/react-server/src/SplitNode.tsx
+++ b/chainforge/react-server/src/SplitNode.tsx
@@ -28,7 +28,7 @@ import {
 } from "./backend/utils";
 
 import { fromMarkdown } from "mdast-util-from-markdown";
-import StorageCache from "./backend/cache";
+import StorageCache, { StringLookup } from "./backend/cache";
 import { ResponseBox } from "./ResponseBoxes";
 import { Root, RootContent } from "mdast";
 import { Dict, TemplateVarInfo } from "./backend/typing";
@@ -289,7 +289,7 @@ const SplitNode: React.FC<SplitNodeProps> = ({ data, id }) => {
           .map((resp_obj: TemplateVarInfo | string) => {
             if (typeof resp_obj === "string")
               return splitText(resp_obj, formatting, true);
-            const texts = splitText(resp_obj?.text ?? "", formatting, true);
+            const texts = splitText(StringLookup.get(resp_obj?.text) ?? "", formatting, true);
             if (texts !== undefined && texts.length >= 1)
               return texts.map(
                 (t: string) =>

--- a/chainforge/react-server/src/TabularDataNode.tsx
+++ b/chainforge/react-server/src/TabularDataNode.tsx
@@ -26,6 +26,7 @@ import { Dict, TabularDataRowType, TabularDataColType } from "./backend/typing";
 import { Position } from "reactflow";
 import { AIGenReplaceTablePopover } from "./AiPopover";
 import { parseTableData } from "./backend/tableUtils";
+import { StringLookup } from "./backend/cache";
 
 const defaultRows: TabularDataRowType[] = [
   {
@@ -469,7 +470,7 @@ const TabularDataNode: React.FC<TabularDataNodeProps> = ({ data, id }) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const [rowValues, setRowValues] = useState<string[]>(
-    tableData.map((row) => row.value || ""),
+    tableData.map((row) => StringLookup.get(row.value) ?? ""),
   );
 
   // Function to add new columns to the right of the existing columns (with optional row values)

--- a/chainforge/react-server/src/VisNode.tsx
+++ b/chainforge/react-server/src/VisNode.tsx
@@ -225,8 +225,9 @@ const VisNode: React.FC<VisNodeProps> = ({ data, id }) => {
 
     const get_llm = (resp_obj: LLMResponse) => {
       if (selectedLLMGroup === "LLM")
-        return typeof resp_obj.llm === "string" || typeof resp_obj.llm === "number"
-          ? (StringLookup.get(resp_obj.llm) ?? "(LLM lookup failed)")
+        return typeof resp_obj.llm === "string" ||
+          typeof resp_obj.llm === "number"
+          ? StringLookup.get(resp_obj.llm) ?? "(LLM lookup failed)"
           : resp_obj.llm?.name;
       else return resp_obj.metavars[selectedLLMGroup] as string;
     };
@@ -347,7 +348,10 @@ const VisNode: React.FC<VisNodeProps> = ({ data, id }) => {
       else return v;
     };
 
-    const castData = (v: LLMResponseData) => (typeof v === "string" || typeof v === "number" ? (StringLookup.get(v) ?? "(unknown lookup error)") : v.d)
+    const castData = (v: LLMResponseData) =>
+      typeof v === "string" || typeof v === "number"
+        ? StringLookup.get(v) ?? "(unknown lookup error)"
+        : v.d;
 
     const get_items = (eval_res_obj?: EvaluationResults) => {
       if (eval_res_obj === undefined) return [];
@@ -482,9 +486,7 @@ const VisNode: React.FC<VisNodeProps> = ({ data, id }) => {
             if (resp_to_x(r) !== name) return;
             x_items = x_items.concat(get_items(r.eval_res));
             text_items = text_items.concat(
-              createHoverTexts(
-                r.responses.map(castData),
-              ),
+              createHoverTexts(r.responses.map(castData)),
             );
           });
         }
@@ -577,11 +579,7 @@ const VisNode: React.FC<VisNodeProps> = ({ data, id }) => {
             if (resp_to_x(r) !== name) return;
             x_items = x_items.concat(get_items(r.eval_res)).flat();
             text_items = text_items
-              .concat(
-                createHoverTexts(
-                  r.responses.map(castData),
-                ),
-              )
+              .concat(createHoverTexts(r.responses.map(castData)))
               .flat();
             y_items = y_items
               .concat(

--- a/chainforge/react-server/src/VisNode.tsx
+++ b/chainforge/react-server/src/VisNode.tsx
@@ -225,8 +225,8 @@ const VisNode: React.FC<VisNodeProps> = ({ data, id }) => {
 
     const get_llm = (resp_obj: LLMResponse) => {
       if (selectedLLMGroup === "LLM")
-        return typeof resp_obj.llm === "string"
-          ? resp_obj.llm
+        return typeof resp_obj.llm === "string" || typeof resp_obj.llm === "number"
+          ? (StringLookup.get(resp_obj.llm) ?? "(LLM lookup failed)")
           : resp_obj.llm?.name;
       else return resp_obj.metavars[selectedLLMGroup] as string;
     };

--- a/chainforge/react-server/src/VisNode.tsx
+++ b/chainforge/react-server/src/VisNode.tsx
@@ -13,9 +13,11 @@ import {
   EvaluationScore,
   JSONCompatible,
   LLMResponse,
+  LLMResponseData,
 } from "./backend/typing";
 import { Status } from "./StatusIndicatorComponent";
 import { grabResponses } from "./backend/backend";
+import { StringLookup } from "./backend/cache";
 
 // Helper funcs
 const splitAndAddBreaks = (s: string, chunkSize: number) => {
@@ -332,7 +334,7 @@ const VisNode: React.FC<VisNodeProps> = ({ data, id }) => {
         ? resp_obj.metavars[varname.slice("__meta_".length)]
         : resp_obj.vars[varname];
       if (v === undefined && empty_str_if_undefined) return "";
-      return v;
+      return StringLookup.get(v) ?? "";
     };
 
     const get_var_and_trim = (
@@ -344,6 +346,8 @@ const VisNode: React.FC<VisNodeProps> = ({ data, id }) => {
       if (v !== undefined) return v.trim();
       else return v;
     };
+
+    const castData = (v: LLMResponseData) => (typeof v === "string" || typeof v === "number" ? (StringLookup.get(v) ?? "(unknown lookup error)") : v.d)
 
     const get_items = (eval_res_obj?: EvaluationResults) => {
       if (eval_res_obj === undefined) return [];
@@ -479,7 +483,7 @@ const VisNode: React.FC<VisNodeProps> = ({ data, id }) => {
             x_items = x_items.concat(get_items(r.eval_res));
             text_items = text_items.concat(
               createHoverTexts(
-                r.responses.map((v) => (typeof v === "string" ? v : v.d)),
+                r.responses.map(castData),
               ),
             );
           });
@@ -575,7 +579,7 @@ const VisNode: React.FC<VisNodeProps> = ({ data, id }) => {
             text_items = text_items
               .concat(
                 createHoverTexts(
-                  r.responses.map((v) => (typeof v === "string" ? v : v.d)),
+                  r.responses.map(castData),
                 ),
               )
               .flat();

--- a/chainforge/react-server/src/backend/__test__/backend.test.ts
+++ b/chainforge/react-server/src/backend/__test__/backend.test.ts
@@ -10,7 +10,7 @@ import {
   ResponseInfo,
   grabResponses,
 } from "../backend";
-import { LLMResponse, Dict } from "../typing";
+import { LLMResponse, Dict, StringOrHash, LLMSpec } from "../typing";
 import StorageCache from "../cache";
 
 test("count queries required", async () => {
@@ -22,7 +22,7 @@ test("count queries required", async () => {
   };
 
   // Double-check the queries required (not loading from cache)
-  const test_count_queries = async (llms: Array<string | Dict>, n: number) => {
+  const test_count_queries = async (llms: Array<StringOrHash | LLMSpec>, n: number) => {
     const { counts, total_num_responses } = await countQueries(
       prompt,
       vars,

--- a/chainforge/react-server/src/backend/__test__/backend.test.ts
+++ b/chainforge/react-server/src/backend/__test__/backend.test.ts
@@ -22,7 +22,10 @@ test("count queries required", async () => {
   };
 
   // Double-check the queries required (not loading from cache)
-  const test_count_queries = async (llms: Array<StringOrHash | LLMSpec>, n: number) => {
+  const test_count_queries = async (
+    llms: Array<StringOrHash | LLMSpec>,
+    n: number,
+  ) => {
     const { counts, total_num_responses } = await countQueries(
       prompt,
       vars,

--- a/chainforge/react-server/src/backend/__test__/cache.test.ts
+++ b/chainforge/react-server/src/backend/__test__/cache.test.ts
@@ -22,7 +22,7 @@ test("saving and loading cache data from localStorage", () => {
   expect(d).toBeUndefined();
 
   // Load cache from localStorage
-  StorageCache.loadFromLocalStorage("test");
+  StorageCache.loadFromLocalStorage("test", false);
 
   // Verify stored data:
   d = StorageCache.get("hello");

--- a/chainforge/react-server/src/backend/__test__/query.test.ts
+++ b/chainforge/react-server/src/backend/__test__/query.test.ts
@@ -56,7 +56,6 @@ async function prompt_model(model: LLM, provider: LLMProvider): Promise<void> {
       `Prompt: ${prompt}\nResponses: ${JSON.stringify(resp_obj.responses)}`,
     );
     expect(resp_obj.responses).toHaveLength(2);
-    expect(resp_obj.raw_response).toHaveLength(2); // these should've been merged
   });
   expect(Object.keys(cache)).toHaveLength(3); // still expect 3 prompts
 
@@ -82,7 +81,6 @@ async function prompt_model(model: LLM, provider: LLMProvider): Promise<void> {
   Object.entries(cache).forEach(([prompt, response]) => {
     const resp_obj = Array.isArray(response) ? response[0] : response;
     expect(resp_obj.responses).toHaveLength(2);
-    expect(resp_obj.raw_response).toHaveLength(2); // these should've been merged
   });
   expect(Object.keys(cache)).toHaveLength(3); // still expect 3 prompts
 }

--- a/chainforge/react-server/src/backend/__test__/utils.test.ts
+++ b/chainforge/react-server/src/backend/__test__/utils.test.ts
@@ -17,7 +17,6 @@ test("merge response objects", () => {
   // Merging two response objects
   const A: RawLLMResponseObject = {
     responses: ["x", "y", "z"],
-    raw_response: ["x", "y", "z"],
     prompt: "this is a test",
     query: {},
     llm: NativeLLM.OpenAI_ChatGPT,
@@ -27,7 +26,6 @@ test("merge response objects", () => {
   };
   const B: RawLLMResponseObject = {
     responses: ["a", "b", "c"],
-    raw_response: { B: "B" },
     prompt: "this is a test 2",
     query: {},
     llm: NativeLLM.OpenAI_ChatGPT,
@@ -40,7 +38,6 @@ test("merge response objects", () => {
   expect(JSON.stringify(C.responses)).toBe(
     JSON.stringify(["x", "y", "z", "a", "b", "c"]),
   );
-  expect(C.raw_response).toHaveLength(4);
   expect(Object.keys(C.vars)).toHaveLength(2);
   expect(Object.keys(C.vars)).toContain("varB1");
   expect(Object.keys(C.metavars)).toHaveLength(1);

--- a/chainforge/react-server/src/backend/ai.ts
+++ b/chainforge/react-server/src/backend/ai.ts
@@ -9,7 +9,7 @@ import {
 } from "./template";
 import { ChatHistoryInfo, Dict, TabularDataColType } from "./typing";
 import { fromMarkdown } from "mdast-util-from-markdown";
-import { sampleRandomElements } from "./utils";
+import { llmResponseDataToString, sampleRandomElements } from "./utils";
 
 export class AIError extends Error {
   constructor(message: string) {
@@ -314,7 +314,7 @@ export async function autofill(
   if (result.errors && Object.keys(result.errors).length > 0)
     throw new Error(Object.values(result.errors)[0].toString());
 
-  const output = result.responses[0].responses[0] as string;
+  const output = llmResponseDataToString(result.responses[0].responses[0]);
 
   console.log("LLM said: ", output);
 
@@ -381,7 +381,7 @@ export async function autofillTable(
       throw new Error(Object.values(result.errors)[0].toString());
 
     // Extract the output from the LLM response
-    const output = result.responses[0].responses[0] as string;
+    const output = llmResponseDataToString(result.responses[0].responses[0]);
     console.log("LLM said: ", output);
     const newRows = decodeTable(output).rows;
 
@@ -451,7 +451,7 @@ ${prompt}: ?`;
     throw new AIError(Object.values(result.errors)[0].toString());
   }
 
-  const output = result.responses[0].responses[0] as string;
+  const output = llmResponseDataToString(result.responses[0].responses[0]);
   return output.trim();
 }
 
@@ -484,7 +484,7 @@ export async function generateColumn(
       apiKeys,
       true,
     );
-    colName = (result.responses[0].responses[0] as string).replace("_", " ");
+    colName = (llmResponseDataToString(result.responses[0].responses[0])).replace("_", " ");
   }
 
   // Remove any leading/trailing whitespace from the column name as well as any double quotes
@@ -573,9 +573,10 @@ export async function generateAndReplace(
   if (result.errors && Object.keys(result.errors).length > 0)
     throw new Error(Object.values(result.errors)[0].toString());
 
-  console.log("LLM said: ", result.responses[0].responses[0]);
+  const resp = llmResponseDataToString(result.responses[0].responses[0]);
+  console.log("LLM said: ", resp);
 
-  const new_items = decode(result.responses[0].responses[0] as string);
+  const new_items = decode(resp);
   return new_items.slice(0, n);
 }
 
@@ -633,7 +634,7 @@ export async function generateAndReplaceTable(
     console.log("LLM said: ", result.responses[0].responses[0]);
 
     const { cols: new_cols, rows: new_rows } = decodeTable(
-      result.responses[0].responses[0] as string,
+      llmResponseDataToString(result.responses[0].responses[0]),
     );
 
     // Return the generated table with "n" number of rows

--- a/chainforge/react-server/src/backend/ai.ts
+++ b/chainforge/react-server/src/backend/ai.ts
@@ -484,7 +484,10 @@ export async function generateColumn(
       apiKeys,
       true,
     );
-    colName = (llmResponseDataToString(result.responses[0].responses[0])).replace("_", " ");
+    colName = llmResponseDataToString(result.responses[0].responses[0]).replace(
+      "_",
+      " ",
+    );
   }
 
   // Remove any leading/trailing whitespace from the column name as well as any double quotes

--- a/chainforge/react-server/src/backend/backend.ts
+++ b/chainforge/react-server/src/backend/backend.ts
@@ -260,6 +260,7 @@ function filterVarsByLLM(vars: PromptVarsDict, llm_key: string): Dict {
         typeof v === "number" ||
         v?.llm === undefined ||
         typeof v.llm === "string" ||
+        typeof v.llm === "number" ||
         v.llm.key === llm_key,
     );
   });

--- a/chainforge/react-server/src/backend/backend.ts
+++ b/chainforge/react-server/src/backend/backend.ts
@@ -257,6 +257,7 @@ function filterVarsByLLM(vars: PromptVarsDict, llm_key: string): Dict {
     _vars[key] = vs.filter(
       (v) =>
         typeof v === "string" ||
+        typeof v === "number" ||
         v?.llm === undefined ||
         typeof v.llm === "string" ||
         v.llm.key === llm_key,
@@ -1288,15 +1289,15 @@ export async function evalWithLLM(
     // Now we need to apply each response as an eval_res (a score) back to each response object,
     // using the aforementioned mapping metadata:
     responses.forEach((r: LLMResponse) => {
-      const resp_obj = resp_objs[r.metavars.__i];
+      const resp_obj = resp_objs[r.metavars.__i as number];
       if (resp_obj.eval_res !== undefined)
-        resp_obj.eval_res.items[r.metavars.__j] = r.responses[0];
+        resp_obj.eval_res.items[r.metavars.__j as number] = r.responses[0];
       else {
         resp_obj.eval_res = {
           items: [],
           dtype: "Categorical",
         };
-        resp_obj.eval_res.items[r.metavars.__j] = r.responses[0];
+        resp_obj.eval_res.items[r.metavars.__j as number] = r.responses[0];
       }
     });
 

--- a/chainforge/react-server/src/backend/cache.ts
+++ b/chainforge/react-server/src/backend/cache.ts
@@ -141,3 +141,55 @@ export default class StorageCache {
     }
   }
 }
+
+
+/** Global string intern table for efficient storage of repeated strings */
+export class StringLookup {
+  private stringToIndex: Map<string, number> = new Map();
+  private indexToString: string[] = [];
+  private static instance: StringLookup;
+
+  /** Gets the string intern lookup table. Initializes it if the singleton instance does not yet exist. */
+  public static getInstance(): StringLookup {
+    if (!StringLookup.instance) {
+      StringLookup.instance = new StringLookup();
+    }
+    return StringLookup.instance;
+  }
+
+  /** Adds a string to the table and returns its index */
+  public static intern(str: string): number {
+    const s = StringLookup.getInstance();
+    if (s.stringToIndex.has(str)) {
+      return s.stringToIndex.get(str)!; // Return existing index
+    }
+
+    // Add new string
+    const index = s.indexToString.length;
+    s.indexToString.push(str);
+    s.stringToIndex.set(str, index);
+
+    return index;
+  }
+
+  /** Retrieves the original string given an index */
+  public static get(index?: number | string): string | undefined {
+    if (typeof index === "string" || index === undefined) return index; 
+    const s = StringLookup.getInstance();
+    return s.indexToString[index]; // O(1) lookup
+  }
+
+  /** Serializes interned strings and their mappings */
+  public static toJSON() {
+    const s = StringLookup.getInstance();
+    return s.indexToString;
+  }
+
+  /** Restores from JSON */
+  static fromJSON(data: { dictionary: string[] }) {
+    const table = new StringLookup();
+    table.indexToString = data.dictionary;
+    table.stringToIndex = new Map(data.dictionary.map((str, i) => [str, i]));
+    StringLookup.instance = table;
+  }
+}

--- a/chainforge/react-server/src/backend/cache.ts
+++ b/chainforge/react-server/src/backend/cache.ts
@@ -173,8 +173,6 @@ export class StringLookup {
     s.indexToString.push(str);
     s.stringToIndex.set(str, index);
 
-    console.log("Interned", s.stringToIndex);
-
     // Save to cache
     StorageCache.store("__s", s.indexToString);
 

--- a/chainforge/react-server/src/backend/query.ts
+++ b/chainforge/react-server/src/backend/query.ts
@@ -153,8 +153,7 @@ export class PromptPipeline {
     // Save the current state of cache'd responses to a JSON file
     // NOTE: We do this to save money --in case something breaks between calls, can ensure we got the data!
     const prompt_str = prompt.toString();
-    if (!(prompt_str in cached_responses))
-      cached_responses[prompt_str] = [];
+    if (!(prompt_str in cached_responses)) cached_responses[prompt_str] = [];
     else if (!Array.isArray(cached_responses[prompt_str]))
       cached_responses[prompt_str] = [cached_responses[prompt_str]];
 

--- a/chainforge/react-server/src/backend/template.ts
+++ b/chainforge/react-server/src/backend/template.ts
@@ -1,6 +1,12 @@
 import { StringLookup } from "./cache";
 import { isEqual } from "./setUtils";
-import { Dict, PromptVarsDict, PromptVarType, StringOrHash, TemplateVarInfo } from "./typing";
+import {
+  Dict,
+  PromptVarsDict,
+  PromptVarType,
+  StringOrHash,
+  TemplateVarInfo,
+} from "./typing";
 
 function len(o: object | string | Array<any>): number {
   // Acts akin to Python's builtin 'len' method
@@ -236,7 +242,8 @@ export class PromptTemplate {
   has_unfilled_settings_var(varname: string): boolean {
     return Object.entries(this.fill_history).some(
       ([key, val]) =>
-        key.startsWith("=") && new StringTemplate(StringLookup.get(val) ?? "").has_vars([varname]),
+        key.startsWith("=") &&
+        new StringTemplate(StringLookup.get(val) ?? "").has_vars([varname]),
     );
   }
 
@@ -259,7 +266,7 @@ export class PromptTemplate {
                 "PL": "Python"
             });
     */
-  fill(paramDict: Dict<PromptVarType>): PromptTemplate {    
+  fill(paramDict: Dict<PromptVarType>): PromptTemplate {
     // Check for special 'past fill history' format:
     let past_fill_history: Dict<StringOrHash> = {};
     let past_metavars: Dict<StringOrHash> = {};
@@ -269,9 +276,15 @@ export class PromptTemplate {
       // Transfer over the fill history and metavars
       Object.values(paramDict).forEach((obj) => {
         if ("fill_history" in (obj as TemplateVarInfo))
-          past_fill_history = { ...(obj as TemplateVarInfo).fill_history, ...past_fill_history };
+          past_fill_history = {
+            ...(obj as TemplateVarInfo).fill_history,
+            ...past_fill_history,
+          };
         if ("metavars" in (obj as TemplateVarInfo))
-          past_metavars = { ...(obj as TemplateVarInfo).metavars, ...past_metavars };
+          past_metavars = {
+            ...(obj as TemplateVarInfo).metavars,
+            ...past_metavars,
+          };
       });
 
       past_fill_history = StringLookup.concretizeDict(past_fill_history);
@@ -286,7 +299,9 @@ export class PromptTemplate {
     }
 
     // Concretize the params
-    paramDict = StringLookup.concretizeDict(paramDict) as Dict<string | TemplateVarInfo>;
+    paramDict = StringLookup.concretizeDict(paramDict) as Dict<
+      string | TemplateVarInfo
+    >;
 
     // For 'settings' template vars of form {=system_msg}, we use the same logic of storing param
     // values as before -- the only difference is that, when it comes to the actual substitution of
@@ -313,9 +328,9 @@ export class PromptTemplate {
     // Perform the fill inside any and all 'settings' template vars
     Object.entries(filled_pt.fill_history).forEach(([key, val]) => {
       if (!key.startsWith("=")) return;
-      filled_pt.fill_history[key] = new StringTemplate(StringLookup.get(val) ?? "").safe_substitute(
-        params_wo_settings,
-      );
+      filled_pt.fill_history[key] = new StringTemplate(
+        StringLookup.get(val) ?? "",
+      ).safe_substitute(params_wo_settings);
     });
 
     // Append any past history passed as vars:
@@ -440,9 +455,16 @@ export class PromptPermutationGenerator {
                 template.has_unfilled_settings_var(other_param)) &&
               Array.isArray(paramDict[other_param])
             ) {
-              for (let i = 0; i < (paramDict[other_param] as PromptVarType[]).length; i++) {
+              for (
+                let i = 0;
+                i < (paramDict[other_param] as PromptVarType[]).length;
+                i++
+              ) {
                 const ov = (paramDict[other_param] as PromptVarType[])[i];
-                if (isDict(ov) && (ov as TemplateVarInfo).associate_id === v_associate_id) {
+                if (
+                  isDict(ov) &&
+                  (ov as TemplateVarInfo).associate_id === v_associate_id
+                ) {
                   // This is a match. We should add the val to our param_fill_dict:
                   param_fill_dict[other_param] = ov;
                   break;
@@ -478,7 +500,9 @@ export class PromptPermutationGenerator {
   }
 
   // Generator class method to yield permutations of a root prompt template
-  *generate(paramDict: PromptVarsDict): Generator<PromptTemplate, boolean, undefined> {
+  *generate(
+    paramDict: PromptVarsDict,
+  ): Generator<PromptTemplate, boolean, undefined> {
     const template =
       typeof this.template === "string"
         ? new PromptTemplate(this.template)

--- a/chainforge/react-server/src/backend/typing.ts
+++ b/chainforge/react-server/src/backend/typing.ts
@@ -68,8 +68,8 @@ export interface HuggingFaceChatHistory {
 // Chat history with 'carried' variable metadata
 export interface ChatHistoryInfo {
   messages: ChatHistory;
-  fill_history: Dict;
-  metavars?: Dict;
+  fill_history: Dict<StringOrHash>;
+  metavars?: Dict<StringOrHash>;
   llm?: string;
 }
 
@@ -156,6 +156,8 @@ export interface ModelSettingsDict {
 
 export type ResponseUID = string;
 
+export type StringOrHash = string | number;
+
 /** What kind of data can be each individual response from the model.
  * string is basic text; but could be images or more data types in the future.
  */
@@ -164,7 +166,7 @@ export type LLMResponseData =
       t: "img"; // type
       d: string; // payload
     }
-  | string;
+  | StringOrHash;
 
 export function isImageResponseData(
   r: LLMResponseData,
@@ -177,11 +179,11 @@ export interface BaseLLMResponseObject {
   /** A unique ID to refer to this response */
   uid: ResponseUID;
   /** The concrete prompt that led to this response. */
-  prompt: string;
+  prompt: StringOrHash;
   /** The variables fed into the prompt. */
-  vars: Dict;
+  vars: Dict<StringOrHash>;
   /** Any associated metavariables. */
-  metavars: Dict;
+  metavars: Dict<StringOrHash>;
   /** The LLM to query (usually a dict of settings) */
   llm: string | LLMSpec;
   /** Optional: The chat history to pass the LLM */
@@ -240,19 +242,19 @@ export type EvaluatedResponsesResults = {
 /** The outputs of prompt nodes, text fields or other data passed internally in the front-end and to the PromptTemplate backend.
  * Used to populate prompt templates and carry variables/metavariables along the chain. */
 export interface TemplateVarInfo {
-  text?: string;
-  image?: string; // base-64 encoding
-  fill_history?: Dict<string>;
-  metavars?: Dict<string>;
+  text?: StringOrHash;
+  image?: StringOrHash; // base-64 encoding
+  fill_history?: Dict<StringOrHash>;
+  metavars?: Dict<StringOrHash>;
   associate_id?: string;
-  prompt?: string;
+  prompt?: StringOrHash;
   uid?: ResponseUID;
   llm?: string | LLMSpec;
   chat_history?: ChatHistory;
 }
 
 export type LLMResponsesByVarDict = Dict<
-  (BaseLLMResponseObject | LLMResponse | TemplateVarInfo | string)[]
+  (BaseLLMResponseObject | LLMResponse | TemplateVarInfo | StringOrHash)[]
 >;
 
 export type VarsContext = {
@@ -260,15 +262,16 @@ export type VarsContext = {
   metavars: string[];
 };
 
-export type PromptVarType = string | TemplateVarInfo;
+export type PromptVarType = StringOrHash | TemplateVarInfo;
 export type PromptVarsDict = {
   [key: string]: PromptVarType[];
 };
 
-export type TabularDataRowType = Dict<string>;
+export type TabularDataRowType = Dict<StringOrHash>;
 export type TabularDataColType = {
   key: string;
   header: string;
 };
 
 export type PythonInterpreter = "flask" | "pyodide";
+

--- a/chainforge/react-server/src/backend/typing.ts
+++ b/chainforge/react-server/src/backend/typing.ts
@@ -13,6 +13,9 @@ export interface Dict<T = any> {
   [key: string]: T;
 }
 
+/** A string or a number representing the index to a hash table (`StringLookup`). */
+export type StringOrHash = string | number;
+
 // Function types
 export type Func<T = void> = (...args: any[]) => T;
 
@@ -156,8 +159,6 @@ export interface ModelSettingsDict {
 
 export type ResponseUID = string;
 
-export type StringOrHash = string | number;
-
 /** What kind of data can be each individual response from the model.
  * string is basic text; but could be images or more data types in the future.
  */
@@ -195,7 +196,7 @@ export interface RawLLMResponseObject extends BaseLLMResponseObject {
   // A snapshot of the exact query (payload) sent to the LLM's API
   query: Dict;
   // The raw JSON response from the LLM
-  // NOTE: This is now deprecated since it wastes precious storage space. 
+  // NOTE: This is now deprecated since it wastes precious storage space.
   // raw_response: Dict;
   // Extracted responses (1 or more) from raw_response
   responses: LLMResponseData[];
@@ -265,7 +266,7 @@ export type VarsContext = {
 
 export type PromptVarType = StringOrHash | TemplateVarInfo;
 export type PromptVarsDict = {
-  [key: string]: PromptVarType[];
+  [key: string]: PromptVarType[] | StringOrHash;
 };
 
 export type TabularDataRowType = Dict<StringOrHash>;
@@ -275,4 +276,3 @@ export type TabularDataColType = {
 };
 
 export type PythonInterpreter = "flask" | "pyodide";
-

--- a/chainforge/react-server/src/backend/typing.ts
+++ b/chainforge/react-server/src/backend/typing.ts
@@ -185,7 +185,7 @@ export interface BaseLLMResponseObject {
   /** Any associated metavariables. */
   metavars: Dict<StringOrHash>;
   /** The LLM to query (usually a dict of settings) */
-  llm: string | LLMSpec;
+  llm: StringOrHash | LLMSpec;
   /** Optional: The chat history to pass the LLM */
   chat_history?: ChatHistory;
 }
@@ -195,7 +195,8 @@ export interface RawLLMResponseObject extends BaseLLMResponseObject {
   // A snapshot of the exact query (payload) sent to the LLM's API
   query: Dict;
   // The raw JSON response from the LLM
-  raw_response: Dict;
+  // NOTE: This is now deprecated since it wastes precious storage space. 
+  // raw_response: Dict;
   // Extracted responses (1 or more) from raw_response
   responses: LLMResponseData[];
   // Token lengths (if given)
@@ -246,10 +247,10 @@ export interface TemplateVarInfo {
   image?: StringOrHash; // base-64 encoding
   fill_history?: Dict<StringOrHash>;
   metavars?: Dict<StringOrHash>;
-  associate_id?: string;
+  associate_id?: StringOrHash;
   prompt?: StringOrHash;
   uid?: ResponseUID;
-  llm?: string | LLMSpec;
+  llm?: StringOrHash | LLMSpec;
   chat_history?: ChatHistory;
 }
 

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -51,7 +51,7 @@ import {
 } from "@mirai73/bedrock-fm";
 import StorageCache, { StringLookup } from "./cache";
 import Compressor from "compressorjs";
-import { Models } from "@mirai73/bedrock-fm/lib/bedrock";
+// import { Models } from "@mirai73/bedrock-fm/lib/bedrock";
 
 const ANTHROPIC_HUMAN_PROMPT = "\n\nHuman:";
 const ANTHROPIC_AI_PROMPT = "\n\nAssistant:";
@@ -2084,7 +2084,7 @@ export const toStandardResponseFormat = (r: Dict | string) => {
     uid: r?.uid ?? r?.batch_id ?? uuid(),
     llm: r?.llm ?? undefined,
     prompt: r?.prompt ?? "",
-    responses: [(typeof r === "string" || typeof r === "number") ? r : r?.text],
+    responses: [typeof r === "string" || typeof r === "number" ? r : r?.text],
     tokens: r?.raw_response?.usage ?? {},
   };
   if (r?.eval_res !== undefined) resp_obj.eval_res = r.eval_res;
@@ -2223,7 +2223,8 @@ export const batchResponsesByUID = (
 
 export function llmResponseDataToString(data: LLMResponseData): string {
   if (typeof data === "string") return data;
-  else if (typeof data === "number") return StringLookup.get(data) ?? "(string lookup failed)";
+  else if (typeof data === "number")
+    return StringLookup.get(data) ?? "(string lookup failed)";
   else return data.d;
 }
 

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -26,6 +26,7 @@ import {
   EvaluationScore,
   LLMResponseData,
   isImageResponseData,
+  StringOrHash,
 } from "./typing";
 import { v4 as uuid } from "uuid";
 import { StringTemplate } from "./template";
@@ -2110,6 +2111,7 @@ export const tagMetadataWithLLM = (input_data: LLMResponsesByVarDict) => {
       if (
         !r ||
         typeof r === "string" ||
+        typeof r === "number" ||
         !r?.llm ||
         typeof r.llm === "string" ||
         !r.llm.key
@@ -2125,20 +2127,20 @@ export const tagMetadataWithLLM = (input_data: LLMResponsesByVarDict) => {
 
 export const extractLLMLookup = (
   input_data: Dict<
-    (string | TemplateVarInfo | BaseLLMResponseObject | LLMResponse)[]
+    (StringOrHash | TemplateVarInfo | BaseLLMResponseObject | LLMResponse)[]
   >,
 ) => {
   const llm_lookup: Dict<string | LLMSpec> = {};
   Object.values(input_data).forEach((resp_objs) => {
     resp_objs.forEach((r) => {
       const llm_name =
-        typeof r === "string"
+        typeof r === "string" || typeof r === "number"
           ? undefined
-          : !r.llm || typeof r.llm === "string"
+          : !r.llm || typeof r.llm === "string" 
             ? r.llm
             : r.llm.key;
       if (
-        typeof r === "string" ||
+        typeof r === "string" || typeof r === "number" ||
         !r.llm ||
         !llm_name ||
         llm_name in llm_lookup

--- a/chainforge/react-server/src/store.tsx
+++ b/chainforge/react-server/src/store.tsx
@@ -22,7 +22,6 @@ import {
   LLMGroup,
   LLMSpec,
   PromptVarType,
-  PromptVarsDict,
   TemplateVarInfo,
   TabularDataColType,
   TabularDataRowType,
@@ -625,7 +624,9 @@ const useStore = create<StoreHandles>((set, get) => ({
                   (key) =>
                     key === "__uid" ||
                     !row[key] ||
-                    ((typeof row[key] === "string" || typeof row[key] === "number") && StringLookup.get(row[key])?.trim() === ""),
+                    ((typeof row[key] === "string" ||
+                      typeof row[key] === "number") &&
+                      StringLookup.get(row[key])?.trim() === ""),
                 )
               )
                 return undefined;
@@ -633,14 +634,20 @@ const useStore = create<StoreHandles>((set, get) => ({
               const row_excluding_col: Dict<string> = {};
               row_keys.forEach((key) => {
                 if (key !== src_col.key && key !== "__uid")
-                  row_excluding_col[col_header_lookup[key]] =
-                    (StringLookup.get(row[key]) ?? "(string lookup failed)").toString();
+                  row_excluding_col[col_header_lookup[key]] = (
+                    StringLookup.get(row[key]) ?? "(string lookup failed)"
+                  ).toString();
               });
               return {
                 // We escape any braces in the source text before they're passed downstream.
                 // This is a special property of tabular data nodes: we don't want their text to be treated as prompt templates.
                 text: escapeBraces(
-                  src_col.key in row ? (StringLookup.get(row[src_col.key]) ?? "(string lookup failed)").toString() : "",
+                  src_col.key in row
+                    ? (
+                        StringLookup.get(row[src_col.key]) ??
+                        "(string lookup failed)"
+                      ).toString()
+                    : "",
                 ),
                 metavars: row_excluding_col,
                 associate_id: row.__uid, // this is used by the backend to 'carry' certain values together

--- a/chainforge/react-server/src/store.tsx
+++ b/chainforge/react-server/src/store.tsx
@@ -29,6 +29,7 @@ import {
 } from "./backend/typing";
 import { TogetherChatSettings } from "./ModelSettingSchemas";
 import { NativeLLM } from "./backend/models";
+import { StringLookup } from "./backend/cache";
 
 // Initial project settings
 const initialAPIKeys = {};
@@ -624,7 +625,7 @@ const useStore = create<StoreHandles>((set, get) => ({
                   (key) =>
                     key === "__uid" ||
                     !row[key] ||
-                    (typeof row[key] === "string" && row[key].trim() === ""),
+                    ((typeof row[key] === "string" || typeof row[key] === "number") && StringLookup.get(row[key])?.trim() === ""),
                 )
               )
                 return undefined;
@@ -633,13 +634,13 @@ const useStore = create<StoreHandles>((set, get) => ({
               row_keys.forEach((key) => {
                 if (key !== src_col.key && key !== "__uid")
                   row_excluding_col[col_header_lookup[key]] =
-                    row[key].toString();
+                    (StringLookup.get(row[key]) ?? "(string lookup failed)").toString();
               });
               return {
                 // We escape any braces in the source text before they're passed downstream.
                 // This is a special property of tabular data nodes: we don't want their text to be treated as prompt templates.
                 text: escapeBraces(
-                  src_col.key in row ? row[src_col.key].toString() : "",
+                  src_col.key in row ? (StringLookup.get(row[src_col.key]) ?? "(string lookup failed)").toString() : "",
                 ),
                 metavars: row_excluding_col,
                 associate_id: row.__uid, // this is used by the backend to 'carry' certain values together
@@ -708,7 +709,7 @@ const useStore = create<StoreHandles>((set, get) => ({
     const store_data = (
       _texts: PromptVarType[],
       _varname: string,
-      _data: PromptVarsDict,
+      _data: Dict<PromptVarType[]>,
     ) => {
       if (_varname in _data) _data[_varname] = _data[_varname].concat(_texts);
       else _data[_varname] = _texts;

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="chainforge",
-    version="0.3.3.1",
+    version="0.3.4.0",
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION
This update brings two major quality-of-life changes:
- Strings throughout the application are now frequently interned in a global `StringLookup` table, to improve performance and reduce duplicate memory usage. This noticeably improves performance when the number of LLM responses start to exceed 1000, and also results in smaller memory footprint for exported .cforge files. 
- Table View in Response Inspectors now uses [Mantine React Table](https://www.mantine-react-table.com). This brings:
    - Sort columns by value
    - Selectively show/hide columns
    - Filter within columns
    - Sticky header when scrolling down the table
    - Pagination to improve performance when rendering large tables
 
In addition, Response Inspectors now try to lazy-load and show a LoadingSpinner when first calculating the selected inspector view. 

This change is a first-step towards moving the `StorageCache` into the Python back-end when the memory footprint exceeds a MB threshold. This will enable a lighter and streamlined front-end when running large-scale experiments.

 > [!WARNING]
> This change touched many source code files in ChainForge and altered the way `cforge` files are imported and exported. Although changes should be backwards-compatible and bug-free, this cannot be guaranteed. If performance breaks, revert to the previous version.

