### PR TITLE
Saved flows sidebar and save button when running locally

### DIFF
--- a/chainforge/flask_app.py
+++ b/chainforge/flask_app.py
@@ -512,7 +512,7 @@ def makeFetchCall():
         ret.headers.add('Access-Control-Allow-Origin', '*')
         return ret
     else:
-        err_msg = "API request to Anthropic failed"
+        err_msg = "API request failed"
         ret = response.json()
         if "error" in ret and "message" in ret["error"]:
             err_msg += ": " + ret["error"]["message"]

--- a/chainforge/react-server/src/App.tsx
+++ b/chainforge/react-server/src/App.tsx
@@ -1212,6 +1212,27 @@ const App = () => {
     else return "Save to local cache";
   }, [isSaving, showSaveSuccess]);
 
+  const flowSidebar = useMemo(() => {
+    if (!IS_RUNNING_LOCALLY) return undefined;
+    return (
+      <FlowSidebar
+        currentFlow={flowFileName}
+        onLoadFlow={(flowData, name) => {
+          if (name !== undefined) setFlowFileName(name);
+          if (flowData !== undefined) {
+            try {
+              importFlowFromJSON(flowData);
+            } catch (error) {
+              console.error(error);
+              setIsLoading(false);
+              if (showAlert) showAlert(error as Error);
+            }
+          }
+        }}
+      />
+    );
+  }, [flowFileName, importFlowFromJSON, showAlert]);
+
   if (!IS_ACCEPTED_BROWSER) {
     return (
       <Box maw={600} mx="auto" mt="40px">
@@ -1267,22 +1288,7 @@ const App = () => {
           message={confirmationDialogProps.message}
           onConfirm={confirmationDialogProps.onConfirm}
         />
-        <FlowSidebar
-          currentFlow={flowFileName}
-          onLoadFlow={(flowData, name) => {
-            if (name !== undefined) setFlowFileName(name);
-
-            if (flowData !== undefined) {
-              try {
-                importFlowFromJSON(flowData);
-              } catch (error) {
-                console.error(error);
-                setIsLoading(false);
-                if (showAlert) showAlert(error as Error);
-              }
-            }
-          }}
-        />
+        {flowSidebar}
 
         {/* <Modal title={'Welcome to ChainForge'} size='400px' opened={welcomeModalOpened} onClose={closeWelcomeModal} yOffset={'6vh'} styles={{header: {backgroundColor: '#FFD700'}, root: {position: 'relative', left: '-80px'}}}>
         <Box m='lg' mt='xl'>
@@ -1294,7 +1300,12 @@ const App = () => {
 
         <div
           id="custom-controls"
-          style={{ position: "fixed", left: "44px", top: "10px", zIndex: 8 }}
+          style={{
+            position: "fixed",
+            left: IS_RUNNING_LOCALLY ? "44px" : "10px",
+            top: "10px",
+            zIndex: 8,
+          }}
         >
           <Flex>
             {addNodeMenu}

--- a/chainforge/react-server/src/FlowSidebar.tsx
+++ b/chainforge/react-server/src/FlowSidebar.tsx
@@ -1,0 +1,255 @@
+import React, { useState, useEffect, useContext } from "react";
+import {
+  IconEdit,
+  IconTrash,
+  IconMenu2,
+  IconX,
+  IconCheck,
+} from "@tabler/icons-react";
+import axios from "axios";
+import { AlertModalContext } from "./AlertModal";
+import { Dict } from "./backend/typing";
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Drawer,
+  Group,
+  Stack,
+  TextInput,
+  Text,
+  Flex,
+  Header,
+  Title,
+  Divider,
+} from "@mantine/core";
+import { FLASK_BASE_URL } from "./backend/utils";
+
+interface FlowSidebarProps {
+  onLoadFlow: (flowFile: Dict<any>, flowName: string) => void;
+}
+
+const FlowSidebar: React.FC<FlowSidebarProps> = ({ onLoadFlow }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [savedFlows, setSavedFlows] = useState<string[]>([]);
+  // const [editingFlow, setEditingFlow] = useState(null);
+  const [editName, setEditName] = useState<string | null>(null);
+  const [newEditName, setNewEditName] = useState<string>("newName");
+
+  // // Pop-up to edit name of a flow
+  // const editTextRef = useState<RenameValueModalRef | null>(null);
+
+  // For displaying alerts
+  const showAlert = useContext(AlertModalContext);
+
+  // Fetch saved flows from the Flask backend
+  const fetchSavedFlowList = async () => {
+    try {
+      const response = await axios.get(`${FLASK_BASE_URL}api/flows`);
+      setSavedFlows(
+        response.data.map((filename: string) =>
+          filename.replace(".cforge", ""),
+        ),
+      );
+    } catch (error) {
+      console.error("Error fetching saved flows:", error);
+    }
+  };
+
+  // Load a flow when clicked, and push it to the caller
+  const handleLoadFlow = async (filename: string) => {
+    try {
+      // Fetch the flow
+      const response = await axios.get(
+        `${FLASK_BASE_URL}api/flows/${filename}`,
+      );
+
+      // Push the flow to the ReactFlow UI. We also pass the filename
+      // so that the caller can use that info to save the right flow when the user presses save.
+      onLoadFlow(response.data, filename);
+
+      setIsOpen(false); // Close sidebar after loading
+    } catch (error) {
+      console.error(`Error loading flow ${filename}:`, error);
+      if (showAlert) showAlert(error as Error);
+    }
+  };
+
+  // Delete a flow
+  const handleDeleteFlow = async (
+    filename: string,
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    event.stopPropagation(); // Prevent triggering the parent click
+    if (window.confirm(`Are you sure you want to delete "${filename}"?`)) {
+      try {
+        await axios.delete(`${FLASK_BASE_URL}api/flows/${filename}`);
+        fetchSavedFlowList(); // Refresh the list
+      } catch (error) {
+        console.error(`Error deleting flow ${filename}:`, error);
+        if (showAlert) showAlert(error as Error);
+      }
+    }
+  };
+
+  // Start editing a flow name
+  const handleEditClick = (
+    flowFile: string,
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    event.stopPropagation(); // Prevent triggering the parent click
+    setEditName(flowFile);
+    setNewEditName(flowFile);
+  };
+
+  // Cancel editing
+  const handleCancelEdit = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    event.stopPropagation(); // Prevent triggering the parent click
+    setEditName(null);
+  };
+
+  // Save the edited flow name
+  const handleSaveEdit = async (
+    oldFilename: string,
+    newFilename: string,
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    event?.stopPropagation(); // Prevent triggering the parent click
+    if (newFilename && newFilename !== oldFilename) {
+      try {
+        await axios.put(`${FLASK_BASE_URL}api/flows/${oldFilename}`, {
+          newName: newFilename,
+        });
+        fetchSavedFlowList(); // Refresh the list
+      } catch (error) {
+        console.error(`Error renaming flow ${oldFilename}:`, error);
+        if (showAlert) showAlert(error as Error);
+      }
+    }
+
+    // No longer editing
+    setEditName(null);
+    setNewEditName("newName");
+  };
+
+  // Load flows when component mounts
+  useEffect(() => {
+    if (isOpen) {
+      fetchSavedFlowList();
+    }
+  }, [isOpen]);
+
+  return (
+    <div className="relative">
+      {/* <RenameValueModal title="Rename flow" label="Edit name" initialValue="" onSubmit={handleEditName} /> */}
+
+      {/* Toggle Button */}
+      <ActionIcon
+        variant="gradient"
+        size="1.625rem"
+        style={{
+          position: "absolute",
+          top: "10px",
+          left: "10px",
+          // left: isOpen ? "250px" : "10px",
+          // transition: "left 0.3s ease-in-out",
+          zIndex: 10,
+        }}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        {isOpen ? <IconX /> : <IconMenu2 />}
+      </ActionIcon>
+
+      {/* Sidebar */}
+      <Drawer
+        opened={isOpen}
+        onClose={() => setIsOpen(false)}
+        position="left"
+        size="250px" // Adjust sidebar width
+        padding="md"
+        withCloseButton={false} // Hide default close button
+      >
+        <Stack spacing="4px" mt="0px">
+          <Flex justify="space-between">
+            <Title order={4} align="center" color="#333">
+              Saved Flows
+            </Title>
+            <ActionIcon onClick={() => setIsOpen(false)}>
+              <IconX />
+            </ActionIcon>
+          </Flex>
+          <Divider />
+          {savedFlows.length === 0 ? (
+            <Text color="dimmed">No saved flows found</Text>
+          ) : (
+            savedFlows.map((flow) => (
+              <Box
+                key={flow}
+                p="6px"
+                sx={(theme) => ({
+                  borderRadius: theme.radius.sm,
+                  cursor: "pointer",
+                  "&:hover": {
+                    backgroundColor:
+                      theme.colorScheme === "dark"
+                        ? theme.colors.dark[6]
+                        : theme.colors.gray[0],
+                  },
+                })}
+                onClick={() => {
+                  if (editName !== flow) handleLoadFlow(flow);
+                }}
+              >
+                {editName === flow ? (
+                  <Group spacing="xs">
+                    <TextInput
+                      value={newEditName}
+                      onChange={(e) => setNewEditName(e.target.value)}
+                      style={{ flex: 1 }}
+                      autoFocus
+                    />
+                    <ActionIcon
+                      color="green"
+                      onClick={(e) => handleSaveEdit(editName, newEditName, e)}
+                    >
+                      <IconCheck size={18} />
+                    </ActionIcon>
+                    <ActionIcon color="gray" onClick={handleCancelEdit}>
+                      <IconX size={18} />
+                    </ActionIcon>
+                  </Group>
+                ) : (
+                  <Flex
+                    justify="space-between"
+                    align="center"
+                    gap="0px"
+                    h="auto"
+                  >
+                    <Text size="sm">{flow}</Text>
+                    <ActionIcon
+                      color="blue"
+                      onClick={(e) => handleEditClick(flow, e)}
+                    >
+                      <IconEdit size={18} />
+                    </ActionIcon>
+                    <ActionIcon
+                      color="red"
+                      onClick={(e) => handleDeleteFlow(flow, e)}
+                    >
+                      <IconTrash size={18} />
+                    </ActionIcon>
+                  </Flex>
+                )}
+                <Divider />
+              </Box>
+            ))
+          )}
+        </Stack>
+      </Drawer>
+    </div>
+  );
+};
+
+export default FlowSidebar;

--- a/chainforge/react-server/src/LLMResponseInspector.tsx
+++ b/chainforge/react-server/src/LLMResponseInspector.tsx
@@ -10,11 +10,9 @@ import React, {
   useRef,
   useMemo,
   useTransition,
-  Suspense,
 } from "react";
 import {
   MultiSelect,
-  Table,
   NativeSelect,
   Checkbox,
   Flex,
@@ -307,7 +305,6 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
     true,
     false,
   ]);
-  const [numMatches, setNumMatches] = useState(-1);
 
   // Count number of response texts wehenever jsonResponses changes
   const numResponses = useMemo(() => {
@@ -1051,8 +1048,6 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
         const divs = groupByVars(responses, selected_vars, [], null);
         setResponseDivs(divs);
       }
-
-      // setNumMatches(numResponsesDisplayed);
     });
   };
 
@@ -1093,10 +1088,7 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
       <Flex gap="6px" align="end" w="100%">
         <TextInput
           id="search_bar"
-          label={
-            "Find"
-            // + (searchValue.length > 0 ? ` (${numMatches}/${numResponses})` : "")
-          }
+          label={"Find"}
           autoComplete="off"
           size={sz}
           placeholder={"Search responses"}
@@ -1144,7 +1136,6 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
       searchValue,
       filterBySearchValue,
       numResponses,
-      numMatches,
       sz,
       toggleCaseSensitivity,
       toggleFilterBySearchValue,

--- a/chainforge/react-server/src/backend/backend.ts
+++ b/chainforge/react-server/src/backend/backend.ts
@@ -713,6 +713,25 @@ export async function saveFlowToLocalFilesystem(
   }
 }
 
+export async function ensureUniqueFlowFilename(
+  filename: string,
+): Promise<string> {
+  try {
+    const response = await axios.put(
+      `${FLASK_BASE_URL}api/getUniqueFlowFilename`,
+      {
+        name: filename,
+      },
+    );
+    return response.data as string;
+  } catch (error) {
+    console.error(
+      `Error contact Flask to ensure unique filename for imported flow. Defaulting to passed filename (warning: risk this overrides an existing flow.) Error: ${(error as Error).toString()}`,
+    );
+    return filename;
+  }
+}
+
 /**
  * Queries LLM(s) with root prompt template `prompt` and prompt input variables `vars`, `n` times per prompt.
  * Soft-fails if API calls fail, and collects the errors in `errors` property of the return object.

--- a/chainforge/react-server/src/backend/backend.ts
+++ b/chainforge/react-server/src/backend/backend.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from "markdown-it";
+import axios from "axios";
 import { v4 as uuid } from "uuid";
 import {
   Dict,
@@ -695,6 +696,21 @@ export async function fetchEnvironAPIKeys(): Promise<Dict<string>> {
     },
     body: "",
   }).then((res) => res.json());
+}
+
+export async function saveFlowToLocalFilesystem(
+  flowJSON: Dict,
+  filename: string,
+): Promise<void> {
+  try {
+    await axios.put(`${FLASK_BASE_URL}api/flows/${filename}`, {
+      flow: flowJSON,
+    });
+  } catch (error) {
+    throw new Error(
+      `Error saving flow with name ${filename}: ${(error as Error).toString()}`,
+    );
+  }
 }
 
 /**

--- a/chainforge/requirements.txt
+++ b/chainforge/requirements.txt
@@ -8,3 +8,4 @@ urllib3==1.26.6
 anthropic
 google-generativeai
 mistune>=2.0
+platformdirs

--- a/chainforge/requirements.txt
+++ b/chainforge/requirements.txt
@@ -5,7 +5,5 @@ requests
 openai
 dalaipy==2.0.2
 urllib3==1.26.6
-anthropic
-google-generativeai
 mistune>=2.0
 platformdirs

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "flask[async]",
         "flask_cors",
         "requests",
+        "platformdirs",
         "urllib3==1.26.6",
         "openai",
         "anthropic",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="chainforge",
-    version="0.3.4.2",
+    version="0.3.4.3",
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",
@@ -24,8 +24,6 @@ setup(
         "platformdirs",
         "urllib3==1.26.6",
         "openai",
-        "anthropic",
-        "google-generativeai",
         "dalaipy>=2.0.2",
         "mistune>=2.0",  # for LLM response markdown parsing
     ],


### PR DESCRIPTION
This change introduces a sidebar to keep track of your saved flows when ChainForge is locally running:

<img width="1202" alt="Screen Shot 2025-03-02 at 4 44 46 PM" src="https://github.com/user-attachments/assets/8736c61f-5a3d-4cef-a82f-20267020a654" />

The saved flows are stored in the platform-appropriate folder provided by `platformdirs`. The specific location appears in the footer of the sidebar (in case you want to manage it yourself). 

In addition, there is a "Save" button. When running locally, this detects the currently opened flow and saves a copy to the disk, adding it to the list in the sidebar. (If the flow is new, it gives it a unique name.) On the browser version, this just controls the autosaving in localStorage. 

Minor changes:
* Removed unnecessary dependencies on `anthropic` and `google` packages. The latter blocked forever when attempting to install `grcpio` on my machine. 