### PR TITLE
Add prompt variants option to Prompt Node

### DIFF
--- a/chainforge/app.py
+++ b/chainforge/app.py
@@ -25,6 +25,10 @@ def main():
     serve_parser.add_argument('--host', 
                               help="The host to run the server on. Defaults to 'localhost'.", 
                               type=str, default="localhost", nargs='?')
+    serve_parser.add_argument('--dir',
+                              help="Set a custom directory to use for saving flows and autosaving. By default, ChainForge uses the user data location suggested by the `platformdirs` module. Should be the full path.",
+                              type=str,
+                              default=None)
 
     args = parser.parse_args()
 
@@ -34,10 +38,13 @@ def main():
         exit(0)
     
     port = args.port if args.port else 8000
-    host = args.host if args.host else "localhost" 
+    host = args.host if args.host else "localhost"
+
+    if args.dir:
+        print(f"Using directory for storing flows: {args.dir}")
 
     print(f"Serving Flask server on {host} on port {port}...")
-    run_server(host=host, port=port, cmd_args=args)
+    run_server(host=host, port=port, flows_dir=args.dir)
 
 if __name__ == "__main__":
     main()

--- a/chainforge/flask_app.py
+++ b/chainforge/flask_app.py
@@ -866,10 +866,12 @@ def get_unique_flow_name():
     except Exception as e:
         return jsonify({"error": str(e)}), 404
 
-def run_server(host="", port=8000, cmd_args=None):
-    global HOSTNAME, PORT
+def run_server(host="", port=8000, flows_dir=None):
+    global HOSTNAME, PORT, FLOWS_DIR
     HOSTNAME = host
-    PORT = port    
+    PORT = port
+    if flows_dir:
+        FLOWS_DIR = flows_dir
     app.run(host=host, port=port)
 
 if __name__ == '__main__':

--- a/chainforge/react-server/src/App.tsx
+++ b/chainforge/react-server/src/App.tsx
@@ -6,7 +6,6 @@ import React, {
   useContext,
   useMemo,
   useTransition,
-  KeyboardEventHandler,
   KeyboardEvent,
 } from "react";
 import ReactFlow, { Controls, Background, ReactFlowInstance } from "reactflow";

--- a/chainforge/react-server/src/App.tsx
+++ b/chainforge/react-server/src/App.tsx
@@ -1334,6 +1334,7 @@ const App = () => {
               ml="sm"
               size="1.625rem"
               onClick={() => saveFlow()}
+              bg="#eee"
               loading={isSaving}
               disabled={isLoading || isSaving}
             >

--- a/chainforge/react-server/src/AreYouSureModal.tsx
+++ b/chainforge/react-server/src/AreYouSureModal.tsx
@@ -5,6 +5,7 @@ import { useDisclosure } from "@mantine/hooks";
 export interface AreYouSureModalProps {
   title: string;
   message: string;
+  color?: string;
   onConfirm?: () => void;
 }
 
@@ -14,7 +15,7 @@ export interface AreYouSureModalRef {
 
 /** Modal that lets user rename a single value, using a TextInput field. */
 const AreYouSureModal = forwardRef<AreYouSureModalRef, AreYouSureModalProps>(
-  function AreYouSureModal({ title, message, onConfirm }, ref) {
+  function AreYouSureModal({ title, message, color, onConfirm }, ref) {
     const [opened, { open, close }] = useDisclosure(false);
     const description = message || "Are you sure?";
 
@@ -37,7 +38,7 @@ const AreYouSureModal = forwardRef<AreYouSureModalRef, AreYouSureModalProps>(
         onClose={close}
         title={title}
         styles={{
-          header: { backgroundColor: "orange", color: "white" },
+          header: { backgroundColor: color ?? "orange", color: "white" },
           root: { position: "relative", left: "-5%" },
         }}
       >
@@ -54,7 +55,7 @@ const AreYouSureModal = forwardRef<AreYouSureModalRef, AreYouSureModalProps>(
         >
           <Button
             variant="light"
-            color="orange"
+            color={color ?? "orange"}
             type="submit"
             w="40%"
             onClick={close}

--- a/chainforge/react-server/src/FlowSidebar.tsx
+++ b/chainforge/react-server/src/FlowSidebar.tsx
@@ -24,7 +24,6 @@ import {
   Tooltip,
 } from "@mantine/core";
 import { FLASK_BASE_URL } from "./backend/utils";
-import { ensureUniqueFlowFilename } from "./backend/backend";
 
 interface FlowFile {
   name: string;

--- a/chainforge/react-server/src/ItemsNode.tsx
+++ b/chainforge/react-server/src/ItemsNode.tsx
@@ -55,7 +55,7 @@ const ItemsNode: React.FC<ItemsNodeProps> = ({ data, id }) => {
   const flags = useStore((state) => state.flags);
 
   const [contentDiv, setContentDiv] = useState<React.ReactNode | null>(null);
-  const [isEditing, setIsEditing] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
   const [csvInput, setCsvInput] = useState<React.ReactNode | null>(null);
   const [countText, setCountText] = useState<React.ReactNode | null>(null);
 

--- a/chainforge/react-server/src/LLMListComponent.tsx
+++ b/chainforge/react-server/src/LLMListComponent.tsx
@@ -23,10 +23,7 @@ import { StrictModeDroppable } from "./StrictModeDroppable";
 import ModelSettingsModal, {
   ModelSettingsModalRef,
 } from "./ModelSettingsModal";
-import {
-  getDefaultModelFormData,
-  getDefaultModelSettings,
-} from "./ModelSettingSchemas";
+import { getDefaultModelSettings } from "./ModelSettingSchemas";
 import useStore, { initLLMProviders, initLLMProviderMenu } from "./store";
 import { Dict, JSONCompatible, LLMGroup, LLMSpec } from "./backend/typing";
 import { useContextMenu } from "mantine-contextmenu";

--- a/chainforge/react-server/src/LLMListComponent.tsx
+++ b/chainforge/react-server/src/LLMListComponent.tsx
@@ -31,31 +31,13 @@ import useStore, { initLLMProviders, initLLMProviderMenu } from "./store";
 import { Dict, JSONCompatible, LLMGroup, LLMSpec } from "./backend/typing";
 import { useContextMenu } from "mantine-contextmenu";
 import { ContextMenuItemOptions } from "mantine-contextmenu/dist/types";
+import { ensureUniqueName } from "./backend/utils";
 
 // The LLM(s) to include by default on a PromptNode whenever one is created.
 // Defaults to ChatGPT (GPT3.5) when running locally, and HF-hosted falcon-7b for online version since it's free.
 const DEFAULT_INIT_LLMS = [initLLMProviders[0]];
 
 // Helper funcs
-// Ensure that a name is 'unique'; if not, return an amended version with a count tacked on (e.g. "GPT-4 (2)")
-const ensureUniqueName = (_name: string, _prev_names: string[]) => {
-  // Strip whitespace around names
-  const prev_names = _prev_names.map((n) => n.trim());
-  const name = _name.trim();
-
-  // Check if name is unique
-  if (!prev_names.includes(name)) return name;
-
-  // Name isn't unique; find a unique one:
-  let i = 2;
-  let new_name = `${name} (${i})`;
-  while (prev_names.includes(new_name)) {
-    i += 1;
-    new_name = `${name} (${i})`;
-  }
-  return new_name;
-};
-
 /** Get position CSS style below and left-aligned to the input element */
 const getPositionCSSStyle = (
   elem: HTMLButtonElement,

--- a/chainforge/react-server/src/LLMResponseInspectorModal.tsx
+++ b/chainforge/react-server/src/LLMResponseInspectorModal.tsx
@@ -71,7 +71,10 @@ const LLMResponseInspectorModal = forwardRef<
           </button>
         </div>
       }
-      styles={{ title: { justifyContent: "space-between", width: "100%" } }}
+      styles={{
+        title: { justifyContent: "space-between", width: "100%" },
+        header: { paddingBottom: "0px" },
+      }}
     >
       <div
         className="inspect-modal-response-container"

--- a/chainforge/react-server/src/MultiEvalNode.tsx
+++ b/chainforge/react-server/src/MultiEvalNode.tsx
@@ -221,10 +221,10 @@ const MultiEvalNode: React.FC<MultiEvalNodeProps> = ({ data, id }) => {
   const bringNodeToFront = useStore((state) => state.bringNodeToFront);
   const inputEdgesForNode = useStore((state) => state.inputEdgesForNode);
 
-  const flags = useStore((state) => state.flags);
-  const AI_SUPPORT_ENABLED = useMemo(() => {
-    return flags.aiSupport;
-  }, [flags]);
+  // const flags = useStore((state) => state.flags);
+  // const AI_SUPPORT_ENABLED = useMemo(() => {
+  //   return flags.aiSupport;
+  // }, [flags]);
 
   const [status, setStatus] = useState<Status>(Status.NONE);
   // For displaying error messages to user

--- a/chainforge/react-server/src/PromptNode.tsx
+++ b/chainforge/react-server/src/PromptNode.tsx
@@ -18,12 +18,10 @@ import {
   Modal,
   Box,
   Tooltip,
-  Group,
   Flex,
   Button,
   ActionIcon,
   Divider,
-  Title,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import {

--- a/chainforge/react-server/src/backend/backend.ts
+++ b/chainforge/react-server/src/backend/backend.ts
@@ -711,10 +711,12 @@ export async function fetchEnvironAPIKeys(): Promise<Dict<string>> {
 export async function saveFlowToLocalFilesystem(
   flowJSON: Dict,
   filename: string,
+  alsoAutosave: boolean,
 ): Promise<void> {
   try {
     await axios.put(`${FLASK_BASE_URL}api/flows/${filename}`, {
       flow: flowJSON,
+      alsoAutosave: alsoAutosave,
     });
   } catch (error) {
     throw new Error(

--- a/chainforge/react-server/src/backend/models.ts
+++ b/chainforge/react-server/src/backend/models.ts
@@ -313,6 +313,8 @@ export const RATE_LIMIT_BY_MODEL: { [key in LLM]?: number } = {
 };
 
 export const RATE_LIMIT_BY_PROVIDER: { [key in LLMProvider]?: number } = {
+  [LLMProvider.OpenAI]: 1000, // Tier 3 pricing limit is 5000 per minute, across most models, we use 1000 to be safe.
+  [LLMProvider.Azure_OpenAI]: 1000, // Tier 3 pricing limit is 5000 per minute, across most models, we use 1000 to be safe.
   [LLMProvider.Anthropic]: 25, // Tier 1 pricing limit is 50 per minute, across all models; we halve this, to be safe.
   [LLMProvider.Together]: 30, // Paid tier limit is 60 per minute, across all models; we halve this, to be safe.
   [LLMProvider.Google]: 1000, // RPM for Google Gemini models 1.5 is quite generous; at base it is 1000 RPM. If you are using the free version it's 15 RPM, but we can expect most CF users to be using paid (and anyway you can just re-run prompt node until satisfied).

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -2398,3 +2398,52 @@ export const compressBase64Image = (b64: string): Promise<string> => {
     )
     .then((compressedBlob) => blobToBase64(compressedBlob as Blob));
 };
+
+/**
+ * Extends array `a` with the values of `b`.
+ * @param a The array to extend (in-place).
+ * @param b The array to add to the end of `a`.
+ * @returns `a`, extended.
+ */
+export const extendArray = <T>(a: Array<T>, b: Array<T>): Array<T> => {
+  for (const i in b) {
+    a.push(b[i]);
+  }
+  return a;
+};
+
+/**
+ * Extends the array `key` in a dict with `values`, creating a new array if the key is missing.
+ * @param dict The dictionary to extend (in-place).
+ * @param key The key of the dictionary.
+ * @param values The new array to append to the end of the dict value for `key`.
+ */
+export const extendArrayDict = <K extends string | number | symbol, V>(
+  dict: Record<K, V[]>,
+  key: K,
+  values: V[],
+): void => {
+  if (!dict[key]) {
+    dict[key] = [];
+  }
+  extendArray(dict[key], values);
+};
+
+/** Ensure that a name is 'unique'; if not, return an amended version with a count tacked on (e.g. "GPT-4 (2)") */
+export const ensureUniqueName = (_name: string, _prev_names: string[]) => {
+  // Strip whitespace around names
+  const prev_names = _prev_names.map((n) => n.trim());
+  const name = _name.trim();
+
+  // Check if name is unique
+  if (!prev_names.includes(name)) return name;
+
+  // Name isn't unique; find a unique one:
+  let i = 2;
+  let new_name = `${name} (${i})`;
+  while (prev_names.includes(new_name)) {
+    i += 1;
+    new_name = `${name} (${i})`;
+  }
+  return new_name;
+};

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -1967,10 +1967,12 @@ export const extractSettingsVars = (vars?: PromptVarsDict) => {
     vars !== undefined &&
     Object.keys(vars).some((k) => k.charAt(0) === "=")
   ) {
-    return transformDict(
-      deepcopy(vars),
-      (k) => k.charAt(0) === "=",
-      (k) => k.substring(1),
+    return StringLookup.concretizeDict(
+      transformDict(
+        deepcopy(vars),
+        (k) => k.charAt(0) === "=",
+        (k) => k.substring(1),
+      ),
     );
   } else return {};
 };

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="chainforge",
-    version="0.3.4.3",
+    version="0.3.4.4",
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION
ChainForge's existing way of comparing prompts is via template chaining. However, new users especially might not know to use this method, and, it is a bit cumbersome to set up, which can inhibit fast iteration. Personally, I have often wanted to put my first prompt in the Prompt Node, and then 'tweak' it later to A/B test changes; it can take some screen real estate and effort to extract out the prompt from the Node, drop it into a TextFields Node, and then link everything back up again. 

This change also:
 - fully moves autosaving, when running locally, to only go through the backend (filesystem), since storing in browser cache is very slow and can freeze the interface for large flows
 - adds a "Duplicate Flow" button
 - improves how autosaving interacts with the "Saved Flows" management when running locally
 - fixes a cache'd responses similarity check bug when loading old flows (pre-string interning) and extending them