### PR TITLE
Add prompt variant labels

### DIFF
--- a/chainforge/react-server/src/LLMResponseInspector.tsx
+++ b/chainforge/react-server/src/LLMResponseInspector.tsx
@@ -475,10 +475,11 @@ const LLMResponseInspector: React.FC<LLMResponseInspectorProps> = ({
           // Plot eval scores on columns
           setTableColVar("$EVAL_RES");
           return;
-        } else if (found_llms.length === 1 && found_vars.length > 1) {
-          setTableColVar(found_vars[0]);
-          return; // useEffect will replot with the new values
         }
+        // else if (found_llms.length === 1 && found_vars.length > 1) {
+        // setTableColVar(found_vars[0]);
+        // return; // useEffect will replot with the new values
+        // }
       }
 
       // If this is the first time receiving responses, set the multiSelectValue to whatever is the first:

--- a/chainforge/react-server/src/LLMResponseInspectorModal.tsx
+++ b/chainforge/react-server/src/LLMResponseInspectorModal.tsx
@@ -54,10 +54,15 @@ const LLMResponseInspectorModal = forwardRef<
       style={{ position: "relative", left: "-5%" }}
       title={
         <div>
-          <span>Response Inspector</span>
+          {/* <span>Response Inspector</span> */}
           <button
             className="custom-button"
-            style={{ marginTop: "auto", marginRight: "14px", float: "right" }}
+            style={{
+              marginTop: "auto",
+              marginRight: "14px",
+              float: "right",
+              pointerEvents: "all",
+            }}
             onClick={() => {
               try {
                 exportToExcel(props.jsonResponses);
@@ -72,13 +77,24 @@ const LLMResponseInspectorModal = forwardRef<
         </div>
       }
       styles={{
-        title: { justifyContent: "space-between", width: "100%" },
-        header: { paddingBottom: "0px" },
+        title: {
+          justifyContent: "space-between",
+          width: "100%",
+          padding: "0px",
+        },
+        header: {
+          paddingBottom: "0px",
+          paddingTop: "12px",
+          marginBottom: "-24px",
+          backgroundColor: "transparent",
+          pointerEvents: "none",
+        },
+        close: { pointerEvents: "all" },
       }}
     >
       <div
         className="inspect-modal-response-container"
-        style={{ padding: "6px", overflow: "scroll" }}
+        style={{ padding: "0px", overflow: "scroll" }}
       >
         <Suspense fallback={<LoadingOverlay visible={true} />}>
           <LLMResponseInspector

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="chainforge",
-    version="0.3.5.2",
+    version="0.3.5.3",
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION
Prompt variants can now be explicitly named. The name will carry over to later nodes. 

For instance, say you have two variants on a Prompt Node. You will now have `Variant 1` and `Variant 2` under a `var` called "prompt [label]." This helps especially if you have very large prompts with minor changes that are hard to compare via the raw text.