### PR TITLE
Added missing Together AI field to GlobalSettingsModal form

### DIFF
--- a/chainforge/react-server/src/GlobalSettingsModal.tsx
+++ b/chainforge/react-server/src/GlobalSettingsModal.tsx
@@ -202,6 +202,7 @@ const GlobalSettingsModal = forwardRef<GlobalSettingsModalRef, object>(
         AWS_Session_Token: "",
         AWS_Region: "us-east-1",
         AmazonBedrock: JSON.stringify({ credentials: {}, region: "us-east-1" }),
+        Together: "",
       },
 
       validate: {


### PR DESCRIPTION
# Description

The Together AI API key wouldn't be displayed after being correctly submitted in the web app's settings modal.

Steps to reproduce:
1. Go to the Settings modal
2. Add Together AI key
3. Click Submit
4. Reload/refresh the page
5. Go to Settings modal -> Together AI field is empty, but all other fields are correctly displayed

It turns out that the Together field was missing from the GlobalSettingsModal form.

# Solution

I added the Together field to the form so the key can be appropriately instantiated when the page loads.