### PR TITLE
added custom chunker support

### DIFF
--- a/chainforge/react-server/src/backend/typing.ts
+++ b/chainforge/react-server/src/backend/typing.ts
@@ -176,6 +176,18 @@ export interface ModelSettingsDict {
   postprocessors: Dict<(val: string | number | boolean) => any>;
 }
 
+/** Internal description of custom chunker settings, passed to react-json-schema */
+export type CustomChunkerSpec = {
+  identifier: string; // Unique key, maps to baseMethod
+  name: string; // User-friendly name for display
+  emoji?: string;
+  settings_schema?: {
+    // Structure mirroring python CustomChunkerSettingsSchema
+    settings: ModelSettingsDict["schema"]["properties"]; // Re-use schema properties structure
+    ui: ModelSettingsDict["uiSchema"]; // Re-use uiSchema structure
+  };
+};
+
 /** Standard properties that every LLM response object must have. */
 export interface BaseLLMResponseObject {
   /** A unique ID to refer to this response */


### PR DESCRIPTION
This PR introduces support for user-defined custom text chunking methods, mirroring the existing system for custom LLM providers.
Users can now upload Python scripts containing functions decorated with @custom_chunker. The backend (in flask_app.py  /app/initCustomChunker) executes these scripts, registers the handlers in ChunkingMethodRegistry, and persists the script and extracted metadata in CUSTOM_CHUNKERS_DIR.
On the frontend, the GlobalSettingsModal includes a dropzone for these scripts. The Zustand store manages customChunkers and chunkerSettingsSchemas (for settings modals), updated via addOrUpdateCustomChunker. The ChunkMethodListComponent integrates these custom chunkers into the selection menu and settings flow, as a separate process from the preset chunkers defined in ChunkMethodSchemas.tsx. I based this off how custom LLM providers are supported.