### PR TITLE
Implement custom provider protocols and update retriever/chunker logic

### DIFF
--- a/chainforge/examples/levenshtein_retriever.py
+++ b/chainforge/examples/levenshtein_retriever.py
@@ -1,0 +1,88 @@
+from typing import List, Dict, Any, Union
+from chainforge.providers import provider
+
+@provider(
+    name="Levenshtein Retriever",
+    emoji="🔢",
+    models=[],
+    rate_limit="sequential",
+    settings_schema={
+        "settings": {
+            "top_k": {
+                "type": "integer",
+                "title": "Top‑K",
+                "default": 5,
+                "minimum": 1
+            }
+        }
+    },
+    category="retriever"
+)
+def LevenshteinRetriever(
+    chunks: List[Dict[str, Any]],
+    queries: List[Union[str, Dict[str, Any]]],
+    settings: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    """
+    For each query (which may be a str or a dict), compute Levenshtein
+    distance against each chunk, returning the top‑K matches.
+    """
+    # Simple DP edit‑distance
+    def lev(a: str, b: str) -> int:
+        m, n = len(a), len(b)
+        dp = [[0]*(n+1) for _ in range(m+1)]
+        for i in range(m+1): dp[i][0] = i
+        for j in range(n+1): dp[0][j] = j
+        for i in range(1, m+1):
+            for j in range(1, n+1):
+                cost = 0 if a[i-1]==b[j-1] else 1
+                dp[i][j] = min(
+                    dp[i-1][j] + 1,
+                    dp[i][j-1] + 1,
+                    dp[i-1][j-1] + cost
+                )
+        return dp[m][n]
+
+    top_k = settings.get("top_k", 5)
+    results: List[Dict[str, Any]] = []
+
+    for q in queries:
+        # normalize query into a dict with a "text" field
+        if isinstance(q, dict):
+            prompt = q.get("text") or q.get("query") or ""
+            query_obj = {**q, "text": prompt}
+        else:
+            prompt = str(q)
+            query_obj = {"text": prompt}
+
+        low = prompt.lower()
+        # score each chunk
+        scored: List[tuple] = []
+        for chunk in chunks:
+            text = chunk.get("text", "")
+            dist = lev(low, text.lower())
+            scored.append((chunk, dist))
+
+        # pick top_k by smallest distance
+        scored.sort(key=lambda x: x[1])
+        top = scored[:top_k]
+
+        # build retrieved_chunks
+        retrieved = []
+        for rank, (chunk, dist) in enumerate(top, start=1):
+            max_len = max(len(prompt), len(chunk.get("text","")), 1)
+            sim = 1 - dist / max_len
+            retrieved.append({
+                "text":         chunk.get("text", ""),
+                "similarity":   sim,
+                "docTitle":     chunk.get("docTitle", ""),
+                "chunkId":      chunk.get("chunkId", ""),
+                "chunkLibrary": chunk.get("chunkLibrary", "")
+            })
+
+        results.append({
+            "query_object":     query_obj,
+            "retrieved_chunks": retrieved
+        })
+
+    return results

--- a/chainforge/examples/paragraph_chunker.py
+++ b/chainforge/examples/paragraph_chunker.py
@@ -1,0 +1,29 @@
+import re
+from chainforge.providers import provider
+from typing import List
+
+@provider(
+    name="Paragraph Chunker",
+    emoji="¶",
+    models=[],                # no LLM models needed
+    rate_limit="sequential",  # chunkers run sequentially
+    settings_schema={},        # no extra settings
+    category="chunker" 
+)
+def ParagraphChunker(
+    text: str
+) -> List[str]:
+    """
+    Splits the input text into paragraphs at blank lines.
+
+    Args:
+      text: the full text to chunk.
+
+    Returns:
+      A list of non‑empty paragraph strings.
+    """
+    # normalize line endings
+    text = text.replace("\r\n", "\n")
+    # split on one-or-more blank lines
+    paras = [p.strip() for p in re.split(r"\n\s*\n+", text) if p.strip()]
+    return paras

--- a/chainforge/react-server/src/ChunkMethodListComponent.tsx
+++ b/chainforge/react-server/src/ChunkMethodListComponent.tsx
@@ -25,6 +25,7 @@ import validator from "@rjsf/validator-ajv8";
 import { v4 as uuid } from "uuid";
 import { ChunkMethodSchemas, ChunkMethodGroups } from "./ChunkMethodSchemas";
 import { transformDict, truncStr } from "./backend/utils";
+import useStore from "./store";
 
 export interface ChunkMethodSpec {
   key: string;
@@ -236,6 +237,8 @@ const ChunkMethodListContainer = forwardRef<
   );
 
   const [menuOpened, setMenuOpened] = useState(false);
+  // Pull in any dropped‑in chunkers
+  const customChunkers = useStore((s) => s.customChunkers);
 
   return (
     <div style={{ padding: 4 }}>
@@ -281,6 +284,25 @@ const ChunkMethodListContainer = forwardRef<
                 {groupIdx < ChunkMethodGroups.length - 1 && <Divider my="xs" />}
               </React.Fragment>
             ))}
+            {/* ── Custom chunkers ── */}
+            {customChunkers.length > 0 && (
+              <>
+                <Divider my="xs" />
+                <Menu.Label>Custom chunkers</Menu.Label>
+                {customChunkers.map((item) => (
+                  <Menu.Item
+                    key={item.baseMethod}
+                    icon={item.emoji ? <Text>{item.emoji}</Text> : undefined}
+                    onClick={() => {
+                      addMethod(item);
+                      setMenuOpened(false);
+                    }}
+                  >
+                    {item.name}
+                  </Menu.Item>
+                ))}
+              </>
+            )}
           </Menu.Dropdown>
         </Menu>
       </Group>

--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -2606,11 +2606,13 @@ export const setCustomProvider = (
   models?: string[],
   rate_limit?: number | string,
   settings_schema?: CustomLLMProviderSpec["settings_schema"],
+  category?: string,
 ) => {
   if (typeof emoji === "string" && (emoji.length === 0 || emoji.length > 2))
     throw new Error(`Emoji for a custom provider must have a character.`);
 
   const new_provider: Dict<JSONCompatible> = { name };
+  new_provider.category = category || "model";
   new_provider.emoji = emoji || "✨";
 
   // Each LLM *model* must have a unique name. To avoid name collisions, for custom providers,
@@ -2709,6 +2711,7 @@ export const setCustomProviders = (providers: CustomLLMProviderSpec[]) => {
       p.models,
       p.rate_limit,
       p.settings_schema,
+      p.category,
     );
 };
 

--- a/chainforge/react-server/src/RetrievalMethodListComponent.tsx
+++ b/chainforge/react-server/src/RetrievalMethodListComponent.tsx
@@ -32,6 +32,7 @@ import {
   retrievalMethodGroups,
   embeddingProviders,
 } from "./RetrievalMethodSchemas";
+import useStore from "./store";
 
 // Individual retrieval method item interface
 export interface RetrievalMethodSpec {
@@ -298,6 +299,7 @@ export const RetrievalMethodListContainer = forwardRef<
   );
 
   const [menuOpened, setMenuOpened] = useState(false);
+  const customRetrievers = useStore((s) => s.customRetrievers || []);
 
   return (
     <div style={{ border: "1px dashed #ccc", borderRadius: 6, padding: 8 }}>
@@ -381,6 +383,24 @@ export const RetrievalMethodListContainer = forwardRef<
                 )}
               </React.Fragment>
             ))}
+            {customRetrievers.length > 0 && (
+              <>
+                <Divider my="xs" />
+                <Menu.Label>Custom Providers</Menu.Label>
+                {customRetrievers.map((prov) => (
+                  <Menu.Item
+                    key={prov.key}
+                    icon={prov.emoji ? <Text>{prov.emoji}</Text> : undefined}
+                    onClick={() => {
+                      addMethod(prov);
+                      setMenuOpened(false);
+                    }}
+                  >
+                    {prov.methodName}
+                  </Menu.Item>
+                ))}
+              </>
+            )}
           </Menu.Dropdown>
         </Menu>
       </Group>

--- a/chainforge/react-server/src/backend/typing.ts
+++ b/chainforge/react-server/src/backend/typing.ts
@@ -211,6 +211,7 @@ export type CustomLLMProviderSpec = {
     settings: Dict<Dict<JSONCompatible>>;
     ui: Dict<Dict<JSONCompatible>>;
   };
+  category?: string;
 };
 
 /** Internal description of model settings, passed to react-json-schema */

--- a/chainforge/react-server/src/store.tsx
+++ b/chainforge/react-server/src/store.tsx
@@ -33,6 +33,8 @@ import { NativeLLM } from "./backend/models";
 import { StringLookup } from "./backend/cache";
 import { saveGlobalConfig } from "./backend/backend";
 import { remove } from "jszip";
+import { ChunkMethodSpec } from "./ChunkMethodListComponent";
+import type { RetrievalMethodSpec } from "./RetrievalMethodListComponent";
 const IS_RUNNING_LOCALLY = APP_IS_RUNNING_LOCALLY();
 
 // Initial project settings
@@ -425,6 +427,14 @@ export interface StoreHandles {
   AvailableLLMs: LLMSpec[];
   setAvailableLLMs: (specs: LLMSpec[]) => void;
 
+  // Custom chunkers loaded via the Custom Providers dropzone
+  customChunkers: ChunkMethodSpec[];
+  setCustomChunkers: (chunkers: ChunkMethodSpec[]) => void;
+
+  // Custom retrievers loaded via the Custom Providers dropzone
+  customRetrievers: RetrievalMethodSpec[];
+  setCustomRetrievers: (retrievers: RetrievalMethodSpec[]) => void;
+
   // API keys to LLM providers
   apiKeys: Dict<string>;
   setAPIKeys: (apiKeys: Dict<string>) => void;
@@ -511,6 +521,16 @@ const useStore = create<StoreHandles>((set, get) => ({
   AvailableLLMs: [...initLLMProviders],
   setAvailableLLMs: (llmProviderList) => {
     set({ AvailableLLMs: llmProviderList });
+  },
+
+  customChunkers: [],
+  setCustomChunkers: (chunkers) => {
+    set({ customChunkers: chunkers });
+  },
+
+  customRetrievers: [],
+  setCustomRetrievers: (retrievers) => {
+    set({ customRetrievers: retrievers });
   },
 
   aiFeaturesProvider: "OpenAI",


### PR DESCRIPTION
- Introduced `CustomChunkerProtocol` and `CustomRetrieverProtocol` to formalize callable interfaces
- Updated `protocol.py` and `ProviderRegistry` logic to register both types via a union
- Created example implementations for testing:
  - `paragraph_chunker.py`
  - `levenshtein_retriever.py`