### PR TITLE
Add OpenAI GPT5 models and auto-retry for Gemini empty responses.

### DIFF
--- a/chainforge/react-server/src/LLMListComponent.tsx
+++ b/chainforge/react-server/src/LLMListComponent.tsx
@@ -31,8 +31,10 @@ import { deepcopy, ensureUniqueName } from "./backend/utils";
 import NestedMenu, { NestedMenuItemProps } from "./NestedMenu";
 
 // The LLM(s) to include by default on a PromptNode whenever one is created.
-// Defaults to ChatGPT (GPT3.5) when running locally, and HF-hosted falcon-7b for online version since it's free.
-const DEFAULT_INIT_LLMS = [initLLMProviders[0]];
+// Defaults to a cheap non-reasoning OpenAI model.
+const DEFAULT_INIT_LLMS = [
+  initLLMProviders.find((m) => m.model === "gpt-4o-mini")!,
+];
 
 // Helper funcs
 /** Get position CSS style below and left-aligned to the input element */

--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -55,6 +55,12 @@ const ChatGPTSettings: ModelSettingsDict = {
         description:
           "Select an OpenAI model to query. For more details on the differences, see the OpenAI API documentation.",
         enum: [
+          "gpt-5",
+          "gpt-5-mini",
+          "gpt-5-nano",
+          "gpt-5-chat-latest",
+          "o3",
+          "o3-mini",
           "gpt-4.1",
           "gpt-4.1-mini",
           "gpt-4.1-nano",
@@ -64,7 +70,6 @@ const ChatGPTSettings: ModelSettingsDict = {
           "o1",
           "o1-mini",
           "o1-pro",
-          "o3-mini",
           "gpt-4.5-preview",
           "gpt-3.5-turbo",
           "gpt-4o-2024-05-13",
@@ -105,11 +110,27 @@ const ChatGPTSettings: ModelSettingsDict = {
         type: "number",
         title: "temperature",
         description:
-          "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
+          "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. NOTE: GPT-5 models will ignore this parameter.",
         default: 1,
         minimum: 0,
         maximum: 2,
         multipleOf: 0.01,
+      },
+      reasoning_effort: {
+        type: "string",
+        title: "reasoning.effort",
+        description:
+          "A parameter specific to o1+ and GPT-5+ models that controls the amount of reasoning effort the model expends when generating a response. NOTE: Currently, only GPT-5 supports the 'minimal' option.",
+        enum: ["minimal", "low", "medium", "high"],
+        default: "medium", // TODO: Add reasoning.summary option to visualize reasoning tokens in UI.
+      },
+      verbosity: {
+        type: "string",
+        title: "verbosity",
+        description:
+          "A parameter specific to GPT-5+ models that determines how many output tokens are generated. Lowering the number of tokens reduces overall latency.",
+        enum: ["low", "medium", "high"],
+        default: "medium",
       },
       response_format: {
         type: "string",
@@ -547,7 +568,7 @@ const GPTImage1Settings: ModelSettingsDict = {
         title: "Model Version",
         description:
           "Select an OpenAI image model to query in the GPT Image series.",
-        enum: ["gpt-image-1"],
+        enum: ["gpt-image-1", "gpt-image-1-mini"],
         default: "gpt-image-1",
       },
       size: {

--- a/chainforge/react-server/src/RequestClarificationModal.tsx
+++ b/chainforge/react-server/src/RequestClarificationModal.tsx
@@ -62,7 +62,6 @@ const RequestClarificationModal: React.FC<RequestClarificationModalProps> = ({
       withCloseButton={false}
       title={title}
       centered
-      style={{ position: "relative", left: "-4%" }}
     >
       <form onSubmit={form.onSubmit(handleSubmit)}>
         <TextInput

--- a/chainforge/react-server/src/backend/models.ts
+++ b/chainforge/react-server/src/backend/models.ts
@@ -37,6 +37,11 @@ export enum NativeLLM {
   OpenAI_GPT4_1 = "gpt-4.1",
   OpenAI_GPT4_1_mini = "gpt-4.1-mini",
   OpenAI_GPT4_1_nano = "gpt-4.1-nano",
+  OpenAI_o3 = "o3",
+  OpenAI_GPT5 = "gpt-5",
+  OpenAI_GPT5_mini = "gpt-5-mini",
+  OpenAI_GPT5_nano = "gpt-5-nano",
+  OpenAI_GPT5_Chat = "gpt-5-chat-latest",
 
   // OpenAI Text Completions (deprecated)
   OpenAI_Davinci003 = "text-davinci-003",
@@ -47,6 +52,7 @@ export enum NativeLLM {
   OpenAI_DallE_2 = "dall-e-2",
   OpenAI_DallE_3 = "dall-e-3",
   OpenAI_GPT_Image_1 = "gpt-image-1",
+  OpenAI_GPT_Image_1_mini = "gpt-image-1-mini",
 
   // Azure OpenAI Endpoints
   Azure_OpenAI = "azure-openai",

--- a/chainforge/react-server/src/store.tsx
+++ b/chainforge/react-server/src/store.tsx
@@ -102,6 +102,27 @@ export const initLLMProviderMenu: (LLMSpec | LLMGroup)[] = [
     emoji: "🤖",
     items: [
       {
+        name: "GPT-5",
+        emoji: "🚀",
+        model: "gpt-5",
+        base_model: "gpt-4",
+        temp: 1.0,
+      },
+      {
+        name: "GPT-5-mini",
+        emoji: "🔬",
+        model: "gpt-5-mini",
+        base_model: "gpt-4",
+        temp: 1.0,
+      },
+      {
+        name: "GPT-5-nano",
+        emoji: "🪲",
+        model: "gpt-5-nano",
+        base_model: "gpt-4",
+        temp: 1.0,
+      },
+      {
         name: "GPT-4o-mini",
         emoji: "🔬",
         model: "gpt-4o-mini",
@@ -130,9 +151,9 @@ export const initLLMProviderMenu: (LLMSpec | LLMGroup)[] = [
         temp: 1.0,
       },
       {
-        name: "o1",
+        name: "o3",
         emoji: "⭕",
-        model: "o1",
+        model: "o3",
         base_model: "gpt-4",
         temp: 1.0,
       },
@@ -140,6 +161,13 @@ export const initLLMProviderMenu: (LLMSpec | LLMGroup)[] = [
         name: "o3-mini",
         emoji: "⭕",
         model: "o3-mini",
+        base_model: "gpt-4",
+        temp: 1.0,
+      },
+      {
+        name: "o1",
+        emoji: "⭕",
+        model: "o1",
         base_model: "gpt-4",
         temp: 1.0,
       },

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="chainforge",
-    version="0.3.6.3",
+    version="0.3.6.4",
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION
Adds GPT-5 endpoints with reasoning and verbosity options:

<img width="1431" height="563" alt="Screen Shot 2025-10-23 at 11 39 15 AM" src="https://github.com/user-attachments/assets/a0ce533c-bc9b-4570-a4f6-e907f5901697" />

Also adds an auto-retry if/when Google Gemini returns empty responses. It's unknown why Google does this, but it could be a faulty endpoint that should return an error the model is overloaded. 