### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/chainforge/flask_app.py
+++ b/chainforge/flask_app.py
@@ -487,6 +487,7 @@ def fetchEnvironAPIKeys():
         'AWS_SESSION_TOKEN': 'AWS_Session_Token',
         'TOGETHER_API_KEY': 'Together',
         'DEEPSEEK_API_KEY': 'DeepSeek',
+        'MINIMAX_API_KEY': 'MiniMax',
     }
     d = { alias: os.environ.get(key) for key, alias in keymap.items() }
     ret = jsonify(d)

--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -472,6 +472,108 @@ const DeepSeekSettings: ModelSettingsDict = {
   postprocessors: ChatGPTSettings.postprocessors,
 };
 
+const MiniMaxSettings: ModelSettingsDict = {
+  fullName: "MiniMax",
+  schema: {
+    type: "object",
+    required: ["shortname"],
+    properties: {
+      shortname: {
+        type: "string",
+        title: "Nickname",
+        description:
+          "Unique identifier to appear in ChainForge. Keep it short.",
+        default: "MiniMax",
+      },
+      model: {
+        type: "string",
+        title: "Model Version",
+        description:
+          "Select a MiniMax model to query. For more details, see the MiniMax API documentation at https://platform.minimaxi.com.",
+        enum: ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+        default: "MiniMax-M2.7",
+        shortname_map: {
+          "MiniMax-M2.7": "M2.7",
+          "MiniMax-M2.7-highspeed": "M2.7-hs",
+        },
+      },
+      system_msg: {
+        type: "string",
+        title: "system_msg",
+        description:
+          "Many conversations begin with a system message to gently instruct the assistant.",
+        default: "You are a helpful assistant.",
+        allow_empty_str: true,
+      },
+      temperature: {
+        type: "number",
+        title: "temperature",
+        description:
+          "What sampling temperature to use, between 0.01 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. Note: MiniMax requires temperature > 0.",
+        default: 0.7,
+        minimum: 0.01,
+        maximum: 1,
+        multipleOf: 0.01,
+      },
+      top_p: {
+        type: "number",
+        title: "top_p",
+        description:
+          "An alternative to sampling with temperature, called nucleus sampling.",
+        default: 1,
+        minimum: 0,
+        maximum: 1,
+        multipleOf: 0.005,
+      },
+      stop: {
+        type: "string",
+        title: "stop sequences",
+        description:
+          'Sequences where the API will stop generating further tokens. Enclose stop sequences in double-quotes "" and use whitespace to separate them.',
+        default: "",
+      },
+      max_tokens: {
+        type: "integer",
+        title: "max_tokens",
+        description:
+          "The maximum number of tokens to generate in the chat completion.",
+      },
+      presence_penalty: {
+        type: "number",
+        title: "presence_penalty",
+        description:
+          "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far.",
+        default: 0,
+        minimum: -2,
+        maximum: 2,
+        multipleOf: 0.005,
+      },
+      frequency_penalty: {
+        type: "number",
+        title: "frequency_penalty",
+        description:
+          "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far.",
+        default: 0,
+        minimum: -2,
+        maximum: 2,
+        multipleOf: 0.005,
+      },
+    },
+  },
+  uiSchema: {
+    ...ChatGPTSettings.uiSchema,
+    model: {
+      "ui:help": "Defaults to MiniMax-M2.7.",
+      "ui:widget": "datalist",
+    },
+    temperature: {
+      "ui:help": "Defaults to 0.7. MiniMax requires temperature > 0.",
+      "ui:widget": "range",
+    },
+  },
+  postprocessors: ChatGPTSettings.postprocessors,
+};
+
 const DalleSettings: ModelSettingsDict = {
   fullName: "Dall-E Image Models (OpenAI)",
   schema: {
@@ -2516,6 +2618,7 @@ export const ModelSettings: Dict<ModelSettingsDict> = {
   "br.meta.llama3": BedrockLlama3Settings,
   together: TogetherChatSettings,
   deepseek: DeepSeekSettings,
+  minimax: MiniMaxSettings,
 };
 
 // A lookup that converts the base_model names into LLMProviders.
@@ -2543,6 +2646,7 @@ export function baseModelToProvider(base_model: string): LLMProvider {
     "br.meta.llama3": LLMProvider.Bedrock,
     together: LLMProvider.Together,
     deepseek: LLMProvider.DeepSeek,
+    minimax: LLMProvider.MiniMax,
   };
   return lookup[base_model] ?? LLMProvider.Custom;
 }
@@ -2564,6 +2668,7 @@ export function getSettingsSchemaForLLM(
     [LLMProvider.Ollama]: OllamaSettings,
     [LLMProvider.Together]: TogetherChatSettings,
     [LLMProvider.DeepSeek]: DeepSeekSettings,
+    [LLMProvider.MiniMax]: MiniMaxSettings,
   };
 
   if (llm_provider === LLMProvider.Custom) return ModelSettings[llm_name];

--- a/chainforge/react-server/src/backend/__test__/minimax.test.ts
+++ b/chainforge/react-server/src/backend/__test__/minimax.test.ts
@@ -1,0 +1,359 @@
+/*
+ * @jest-environment jsdom
+ */
+
+// Pre-existing test infra issues in this repo (8 of 9 test suites fail):
+// 1. cache.ts calls APP_IS_RUNNING_LOCALLY() at module load before `let` var is init
+// 2. @google/genai uses ESM syntax not supported by Jest/CRA
+// 3. pyodide/exec-py.js uses import.meta.url not supported outside ESM
+// Mock these to allow our tests to load.
+jest.mock("../cache", () => ({
+  __esModule: true,
+  default: class StorageCache {
+    static getInstance() {
+      return new StorageCache();
+    }
+  },
+}));
+jest.mock("@google/genai", () => ({ GoogleGenAI: jest.fn() }));
+jest.mock("@azure/openai", () => ({
+  AzureKeyCredential: jest.fn(),
+  OpenAIClient: jest.fn(),
+}));
+jest.mock("../pyodide/exec-py", () => ({ execPy: jest.fn() }));
+jest.mock("../../store", () => ({
+  __esModule: true,
+  default: { getState: () => ({ AvailableLLMs: [], setAvailableLLMs: jest.fn() }) },
+}));
+
+import {
+  call_minimax,
+  extract_responses,
+  set_api_keys,
+} from "../utils";
+import {
+  LLMProvider,
+  NativeLLM,
+  getProvider,
+  getEnumName,
+  RATE_LIMIT_BY_PROVIDER,
+} from "../models";
+import { expect, test, describe, beforeAll } from "@jest/globals";
+import {
+  ModelSettings,
+  baseModelToProvider,
+  getSettingsSchemaForLLM,
+  getTemperatureSpecForModel,
+  getDefaultModelFormData,
+  postProcessFormData,
+} from "../../ModelSettingSchemas";
+
+// ─── Unit Tests ─────────────────────────────────────────────────────────────
+
+describe("MiniMax provider detection", () => {
+  test("NativeLLM enum contains MiniMax models", () => {
+    expect(NativeLLM.MiniMax_M2_7).toBe("MiniMax-M2.7");
+    expect(NativeLLM.MiniMax_M2_7_highspeed).toBe("MiniMax-M2.7-highspeed");
+  });
+
+  test("LLMProvider enum contains MiniMax", () => {
+    expect(LLMProvider.MiniMax).toBe("minimax");
+  });
+
+  test("getProvider identifies MiniMax models", () => {
+    expect(getProvider(NativeLLM.MiniMax_M2_7)).toBe(LLMProvider.MiniMax);
+    expect(getProvider(NativeLLM.MiniMax_M2_7_highspeed)).toBe(
+      LLMProvider.MiniMax,
+    );
+  });
+
+  test("getEnumName returns MiniMax enum names", () => {
+    expect(getEnumName(NativeLLM, "MiniMax-M2.7")).toBe("MiniMax_M2_7");
+    expect(getEnumName(NativeLLM, "MiniMax-M2.7-highspeed")).toBe(
+      "MiniMax_M2_7_highspeed",
+    );
+  });
+
+  test("MiniMax has rate limit configured", () => {
+    expect(RATE_LIMIT_BY_PROVIDER[LLMProvider.MiniMax]).toBe(1000);
+  });
+});
+
+describe("MiniMax settings schema", () => {
+  test("ModelSettings contains minimax entry", () => {
+    expect(ModelSettings).toHaveProperty("minimax");
+    expect(ModelSettings.minimax.fullName).toBe("MiniMax");
+  });
+
+  test("baseModelToProvider maps minimax correctly", () => {
+    expect(baseModelToProvider("minimax")).toBe(LLMProvider.MiniMax);
+  });
+
+  test("getSettingsSchemaForLLM returns MiniMax schema", () => {
+    const schema = getSettingsSchemaForLLM("MiniMax-M2.7");
+    expect(schema).toBeDefined();
+    expect(schema?.fullName).toBe("MiniMax");
+  });
+
+  test("MiniMax schema has required model properties", () => {
+    const schema = ModelSettings.minimax.schema;
+    expect(schema.properties).toHaveProperty("shortname");
+    expect(schema.properties).toHaveProperty("model");
+    expect(schema.properties).toHaveProperty("temperature");
+    expect(schema.properties).toHaveProperty("system_msg");
+    expect(schema.properties).toHaveProperty("top_p");
+    expect(schema.properties).toHaveProperty("max_tokens");
+    expect(schema.properties).toHaveProperty("stop");
+  });
+
+  test("MiniMax model enum includes both models", () => {
+    const modelEnum = ModelSettings.minimax.schema.properties.model.enum;
+    expect(modelEnum).toContain("MiniMax-M2.7");
+    expect(modelEnum).toContain("MiniMax-M2.7-highspeed");
+  });
+
+  test("MiniMax temperature has correct bounds for temp > 0", () => {
+    const tempSpec = ModelSettings.minimax.schema.properties.temperature;
+    expect(tempSpec.minimum).toBe(0.01);
+    expect(tempSpec.maximum).toBe(1);
+    expect(tempSpec.default).toBe(0.7);
+  });
+
+  test("getTemperatureSpecForModel returns correct spec for minimax", () => {
+    const spec = getTemperatureSpecForModel("minimax");
+    expect(spec).toBeDefined();
+    expect(spec?.minimum).toBe(0.01);
+    expect(spec?.maximum).toBe(1);
+    expect(spec?.default).toBe(0.7);
+  });
+
+  test("MiniMax default form data has expected values", () => {
+    const defaults = getDefaultModelFormData(ModelSettings.minimax);
+    expect(defaults.shortname).toBe("MiniMax");
+    expect(defaults.model).toBe("MiniMax-M2.7");
+    expect(defaults.temperature).toBe(0.7);
+    expect(defaults.system_msg).toBe("You are a helpful assistant.");
+  });
+
+  test("MiniMax schema has shortname_map for models", () => {
+    const shortNameMap =
+      ModelSettings.minimax.schema.properties.model.shortname_map;
+    expect(shortNameMap).toBeDefined();
+    expect(shortNameMap["MiniMax-M2.7"]).toBe("M2.7");
+    expect(shortNameMap["MiniMax-M2.7-highspeed"]).toBe("M2.7-hs");
+  });
+
+  test("postProcessFormData strips model and shortname", () => {
+    const formData = {
+      shortname: "MiniMax",
+      model: "MiniMax-M2.7",
+      temperature: 0.7,
+      system_msg: "You are a helpful assistant.",
+    };
+    const processed = postProcessFormData(ModelSettings.minimax, formData);
+    expect(processed).not.toHaveProperty("shortname");
+    expect(processed).not.toHaveProperty("model");
+    expect(processed).toHaveProperty("temperature");
+    expect(processed).toHaveProperty("system_msg");
+  });
+
+  test("MiniMax stop postprocessor parses quoted strings", () => {
+    const postprocessors = ModelSettings.minimax.postprocessors;
+    expect(postprocessors).toBeDefined();
+    if (postprocessors?.stop) {
+      const result = postprocessors.stop('"stop1" "stop2"');
+      expect(result).toEqual(["stop1", "stop2"]);
+    }
+  });
+
+  test("MiniMax stop postprocessor handles empty string", () => {
+    const postprocessors = ModelSettings.minimax.postprocessors;
+    if (postprocessors?.stop) {
+      const result = postprocessors.stop("");
+      expect(result).toEqual([]);
+    }
+  });
+});
+
+describe("MiniMax response extraction", () => {
+  test("extract_responses handles OpenAI-compatible MiniMax chat response", () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: { content: "Hello from MiniMax!" },
+          finish_reason: "stop",
+        },
+        {
+          message: { content: "Another response." },
+          finish_reason: "stop",
+        },
+      ],
+    };
+    const responses = extract_responses(
+      mockResponse,
+      NativeLLM.MiniMax_M2_7,
+      LLMProvider.MiniMax,
+    );
+    expect(responses).toHaveLength(2);
+    expect(responses[0]).toBe("Hello from MiniMax!");
+    expect(responses[1]).toBe("Another response.");
+  });
+
+  test("extract_responses handles single choice", () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: { content: "Single response from MiniMax M2.7." },
+          finish_reason: "stop",
+        },
+      ],
+    };
+    const responses = extract_responses(
+      mockResponse,
+      NativeLLM.MiniMax_M2_7_highspeed,
+      LLMProvider.MiniMax,
+    );
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toBe("Single response from MiniMax M2.7.");
+  });
+
+  test("extract_responses handles empty choices", () => {
+    const mockResponse = { choices: [] };
+    const responses = extract_responses(
+      mockResponse,
+      NativeLLM.MiniMax_M2_7,
+      LLMProvider.MiniMax,
+    );
+    expect(responses).toHaveLength(0);
+  });
+
+  test("extract_responses handles function_call in MiniMax response", () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: "",
+            function_call: {
+              name: "get_weather",
+              arguments: '{"city": "Beijing"}',
+            },
+          },
+          finish_reason: "function_call",
+        },
+      ],
+    };
+    const responses = extract_responses(
+      mockResponse,
+      NativeLLM.MiniMax_M2_7,
+      LLMProvider.MiniMax,
+    );
+    expect(responses).toHaveLength(1);
+    expect((responses[0] as string).startsWith("[[FUNCTION]]")).toBe(true);
+  });
+});
+
+describe("MiniMax call_minimax validation", () => {
+  // Note: set_api_keys with empty string does not clear env-sourced keys
+  // (key_is_present returns false for empty strings, so the key is never updated).
+  // This test only works when MINIMAX_API_KEY is not set in the environment.
+  const describeIfNoKey = process.env.MINIMAX_API_KEY
+    ? describe.skip
+    : describe;
+  describeIfNoKey("without env key", () => {
+    test("call_minimax throws when no API key is set", async () => {
+      await expect(
+        call_minimax(
+          "test prompt",
+          NativeLLM.MiniMax_M2_7,
+          1,
+          0.7,
+        ),
+      ).rejects.toThrow("Could not find a MiniMax API key");
+    });
+  });
+});
+
+// ─── Integration Tests ──────────────────────────────────────────────────────
+// These tests require MINIMAX_API_KEY to be set in the environment.
+
+const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+const describeIfKey = MINIMAX_API_KEY
+  ? describe
+  : describe.skip;
+
+describeIfKey("MiniMax API integration tests", () => {
+  beforeAll(() => {
+    if (MINIMAX_API_KEY) {
+      set_api_keys({ MiniMax: MINIMAX_API_KEY });
+    }
+  });
+
+  test(
+    "call_minimax returns valid chat response",
+    async () => {
+      const [query, response] = await call_minimax(
+        "What is 2 + 2? Reply with just the number.",
+        NativeLLM.MiniMax_M2_7,
+        1,
+        0.7,
+      );
+
+      expect(query).toHaveProperty("model");
+      expect(query).toHaveProperty("temperature");
+      expect(query.temperature).toBeGreaterThanOrEqual(0.01);
+
+      expect(response).toHaveProperty("choices");
+      expect(response.choices).toHaveLength(1);
+      expect(response.choices[0]).toHaveProperty("message");
+      expect(typeof response.choices[0].message.content).toBe("string");
+
+      const resps = extract_responses(
+        response,
+        NativeLLM.MiniMax_M2_7,
+        LLMProvider.MiniMax,
+      );
+      expect(resps).toHaveLength(1);
+      expect(typeof resps[0]).toBe("string");
+      expect((resps[0] as string).includes("4")).toBe(true);
+    },
+    60000,
+  );
+
+  test(
+    "call_minimax clamps temperature > 0",
+    async () => {
+      // Pass temperature=0, should be clamped to 0.01
+      const [query] = await call_minimax(
+        "Say hello.",
+        NativeLLM.MiniMax_M2_7,
+        1,
+        0, // zero temperature
+      );
+      // The clamped temperature should be 0.01
+      expect(query.temperature).toBeGreaterThan(0);
+    },
+    30000,
+  );
+
+  test(
+    "call_minimax with system message",
+    async () => {
+      const [query, response] = await call_minimax(
+        "What is your role?",
+        NativeLLM.MiniMax_M2_7,
+        1,
+        0.7,
+        { system_msg: "You are a pirate. Always respond like a pirate." },
+      );
+
+      const resps = extract_responses(
+        response,
+        NativeLLM.MiniMax_M2_7,
+        LLMProvider.MiniMax,
+      );
+      expect(resps).toHaveLength(1);
+      expect(typeof resps[0]).toBe("string");
+    },
+    30000,
+  );
+});

--- a/chainforge/react-server/src/backend/models.ts
+++ b/chainforge/react-server/src/backend/models.ts
@@ -93,6 +93,10 @@ export enum NativeLLM {
   DeepSeek_Chat = "deepseek-chat",
   DeepSeek_Reasoner = "deepseek-reasoner",
 
+  // MiniMax
+  MiniMax_M2_7 = "MiniMax-M2.7",
+  MiniMax_M2_7_highspeed = "MiniMax-M2.7-highspeed",
+
   // Aleph Alpha
   Aleph_Alpha_Luminous_Extended = "luminous-extended",
   Aleph_Alpha_Luminous_ExtendedControl = "luminous-extended-control",
@@ -245,6 +249,7 @@ export enum LLMProvider {
   Bedrock = "bedrock",
   Together = "together",
   DeepSeek = "deepseek",
+  MiniMax = "minimax",
   Custom = "__custom",
 }
 
@@ -265,6 +270,7 @@ export function getProvider(llm: LLM): LLMProvider | undefined {
   else if (llm_name?.startsWith("Bedrock")) return LLMProvider.Bedrock;
   else if (llm_name?.startsWith("Together")) return LLMProvider.Together;
   else if (llm_name?.startsWith("DeepSeek")) return LLMProvider.DeepSeek;
+  else if (llm_name?.startsWith("MiniMax")) return LLMProvider.MiniMax;
   else if (llm.toString().startsWith("__custom/")) return LLMProvider.Custom;
 
   return undefined;
@@ -324,6 +330,7 @@ export const RATE_LIMIT_BY_PROVIDER: { [key in LLMProvider]?: number } = {
   [LLMProvider.Together]: 30, // Paid tier limit is 60 per minute, across all models; we halve this, to be safe.
   [LLMProvider.Google]: 1000, // RPM for Google Gemini models 1.5 is quite generous; at base it is 1000 RPM. If you are using the free version it's 15 RPM, but we can expect most CF users to be using paid (and anyway you can just re-run prompt node until satisfied).
   [LLMProvider.DeepSeek]: 1000, // DeepSeek does not constrain users atm but they might in the future. To be safe we are limiting it to 1000 queries per minute.
+  [LLMProvider.MiniMax]: 1000, // MiniMax API rate limits are generous; 1000 RPM to be safe.
 };
 
 // Max concurrent requests. Add to this to further constrain the rate limiter.

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -166,6 +166,7 @@ let AWS_SESSION_TOKEN = get_environ("AWS_SESSION_TOKEN");
 let AWS_REGION = get_environ("AWS_REGION");
 let TOGETHER_API_KEY = get_environ("TOGETHER_API_KEY");
 let DEEPSEEK_API_KEY = get_environ("DEEPSEEK_API_KEY");
+let MINIMAX_API_KEY = get_environ("MINIMAX_API_KEY");
 
 /**
  * Sets the local API keys for the revelant LLM API(s).
@@ -201,6 +202,7 @@ export function set_api_keys(api_keys: Dict<string>): void {
   if (key_is_present("AWS_Region")) AWS_REGION = api_keys.AWS_Region;
   if (key_is_present("Together")) TOGETHER_API_KEY = api_keys.Together;
   if (key_is_present("DeepSeek")) DEEPSEEK_API_KEY = api_keys.DeepSeek;
+  if (key_is_present("MiniMax")) MINIMAX_API_KEY = api_keys.MiniMax;
 }
 
 export function get_azure_openai_api_keys(): [
@@ -383,13 +385,14 @@ export async function call_chatgpt(
   BASE_URL?: string,
   API_KEY?: string,
 ): Promise<[Dict, Dict]> {
-  if (!OPENAI_API_KEY)
+  const effectiveKey = API_KEY ?? OPENAI_API_KEY;
+  if (!effectiveKey)
     throw new Error(
       "Could not find an OpenAI API key. Double-check that your API key is set in Settings or in your local environment.",
     );
 
   const configuration = new OpenAIConfig({
-    apiKey: API_KEY ?? OPENAI_API_KEY,
+    apiKey: effectiveKey,
     basePath: BASE_URL ?? OPENAI_BASE_URL ?? undefined,
   });
 
@@ -539,6 +542,41 @@ export async function call_deepseek(
     images,
     "https://api.deepseek.com",
     DEEPSEEK_API_KEY,
+  );
+}
+
+/**
+ * Calls MiniMax models via MiniMax's OpenAI-compatible API.
+ */
+export async function call_minimax(
+  prompt: string,
+  model: LLM,
+  n = 1,
+  temperature = 1.0,
+  params?: Dict,
+  should_cancel?: () => boolean,
+  images?: string[],
+): Promise<[Dict, Dict]> {
+  if (!MINIMAX_API_KEY)
+    throw new Error(
+      "Could not find a MiniMax API key. Double-check that your API key is set in Settings or in your local environment.",
+    );
+
+  console.log(`Querying MiniMax model '${model}' with prompt '${prompt}'...`);
+
+  // MiniMax requires temperature to be strictly greater than 0
+  const clampedTemp = Math.max(temperature, 0.01);
+
+  return await call_chatgpt(
+    prompt,
+    model,
+    n,
+    clampedTemp,
+    params,
+    should_cancel,
+    images,
+    "https://api.minimax.io/v1",
+    MINIMAX_API_KEY,
   );
 }
 
@@ -1714,6 +1752,7 @@ export async function call_llm(
   else if (llm_provider === LLMProvider.Bedrock) call_api = call_bedrock;
   else if (llm_provider === LLMProvider.Together) call_api = call_together;
   else if (llm_provider === LLMProvider.DeepSeek) call_api = call_deepseek;
+  else if (llm_provider === LLMProvider.MiniMax) call_api = call_minimax;
   if (call_api === undefined)
     throw new Error(
       `Adapter for Language model ${llm} and ${llm_provider} not found`,
@@ -1918,6 +1957,8 @@ export function extract_responses(
     case LLMProvider.Together:
       return _extract_openai_responses(response as Dict[]);
     case LLMProvider.DeepSeek:
+      return _extract_openai_responses(response as Dict[]);
+    case LLMProvider.MiniMax:
       return _extract_openai_responses(response as Dict[]);
     default:
       if (

--- a/chainforge/react-server/src/store.tsx
+++ b/chainforge/react-server/src/store.tsx
@@ -276,6 +276,26 @@ export const initLLMProviderMenu: (LLMSpec | LLMGroup)[] = [
     ],
   },
   {
+    group: "MiniMax",
+    emoji: "🔮",
+    items: [
+      {
+        name: "MiniMax M2.7",
+        emoji: "🔮",
+        model: "MiniMax-M2.7",
+        base_model: "minimax",
+        temp: 0.7,
+      },
+      {
+        name: "MiniMax M2.7 Highspeed",
+        emoji: "⚡",
+        model: "MiniMax-M2.7-highspeed",
+        base_model: "minimax",
+        temp: 0.7,
+      },
+    ],
+  },
+  {
     group: "HuggingFace",
     emoji: "🤗",
     items: [


### PR DESCRIPTION
## Summary

Add **MiniMax** as a first-class LLM provider in ChainForge, enabling users to query MiniMax M2.7 and M2.7-highspeed models directly from the visual prompt-testing UI.

### Changes

- **Provider registration** (models.ts): NativeLLM enum entries, LLMProvider.MiniMax, getProvider() detection, rate limit (1000 RPM)
- **API integration** (utils.ts): call_minimax() function using OpenAI-compatible API at https://api.minimax.io/v1, temperature clamping (min 0.01) per MiniMax requirement, response extraction via existing OpenAI handler
- **Bugfix** (utils.ts): call_chatgpt() now respects custom API_KEY parameter - previously it threw no OpenAI key even when a custom key was passed by providers like DeepSeek/MiniMax
- **Settings schema** (ModelSettingSchemas.tsx): Full model settings form with temperature (0.01-1.0, default 0.7), system message, top_p, max_tokens, stop sequences, presence/frequency penalty
- **UI menu** (store.tsx): MiniMax group with M2.7 and M2.7-highspeed entries
- **Backend env mapping** (flask_app.py): MINIMAX_API_KEY environment variable support
- **Tests** (minimax.test.ts): 25 tests - 21 unit tests (enum values, provider detection, schema validation, response extraction, form data processing) + 3 integration tests (live API call, temperature clamping, system message) + 1 conditional test

### How it works

MiniMax follows the same pattern as DeepSeek: an OpenAI-compatible wrapper that delegates to call_chatgpt() with a custom base URL and API key. Users just need to set their MINIMAX_API_KEY in Settings.

## Test plan

- [x] All 21 unit tests pass
- [x] All 3 integration tests pass (with MINIMAX_API_KEY set)
- [x] No regressions in existing test suite (pre-existing failures remain unchanged)
- [ ] Manual verification: add MiniMax model from UI dropdown, query with prompt, verify response
