### PR TITLE
fix: update deprecated Hugging Face inference API endpoint

### DIFF
--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -1149,7 +1149,7 @@ export async function call_huggingface(
   const url =
     using_custom_model_endpoint && params?.custom_model.startsWith("https:")
       ? params.custom_model
-      : `https://api-inference.huggingface.co/models/${
+      : `https://api-inference.huggingface.co/inference-endpoint/${
           using_custom_model_endpoint ? params?.custom_model.trim() : model
         }`;
 


### PR DESCRIPTION
Fixes #406 - Hugging Face provider calls deprecated api-inference.huggingface.co and fails with 410 Gone