### PR TITLE
Add in-browser LLMs and set Qwen2.5 0.5B as default. Add Safari support.

### DIFF
--- a/chainforge/flask_app.py
+++ b/chainforge/flask_app.py
@@ -487,6 +487,7 @@ def fetchEnvironAPIKeys():
         'AWS_SESSION_TOKEN': 'AWS_Session_Token',
         'TOGETHER_API_KEY': 'Together',
         'DEEPSEEK_API_KEY': 'DeepSeek',
+        'MINIMAX_API_KEY': 'MiniMax',
     }
     d = { alias: os.environ.get(key) for key, alias in keymap.items() }
     ret = jsonify(d)

--- a/chainforge/react-server/craco.config.js
+++ b/chainforge/react-server/craco.config.js
@@ -9,6 +9,14 @@ module.exports = {
   },
   webpack: {
     configure: {
+      // WebLLM currently publishes sourcemap references to TS sources that are
+      // not included in the npm package. Ignore only those warnings.
+      ignoreWarnings: [
+        {
+          module: /@mlc-ai\/web-llm/,
+          message: /Failed to parse source map/,
+        },
+      ],
       resolve: {
         fallback: {
           process: require.resolve("process/browser"),

--- a/chainforge/react-server/package-lock.json
+++ b/chainforge/react-server/package-lock.json
@@ -22,6 +22,7 @@
         "@mantine/form": "^6.0.11",
         "@mantine/prism": "^6.0.15",
         "@mirai73/bedrock-fm": "^0.4.10",
+        "@mlc-ai/web-llm": "^0.2.84",
         "@reactflow/background": "^11.2.0",
         "@reactflow/controls": "^11.1.11",
         "@reactflow/core": "^11.7.0",
@@ -4738,6 +4739,15 @@
       "integrity": "sha512-j4Nx9RcrnGoue14MhR0LUzB8LdjfwIQ4FVkkytAMalMU43oO/LNcw4gJGLhrNOaTLRztICe24rIJCrfpnxa7jA==",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.507.0"
+      }
+    },
+    "node_modules/@mlc-ai/web-llm": {
+      "version": "0.2.84",
+      "resolved": "https://registry.npmjs.org/@mlc-ai/web-llm/-/web-llm-0.2.84.tgz",
+      "integrity": "sha512-hrOWzK4/nGNmgoRKT8pgVmZZ2oEPpbblIWQOwpqNyvK2dysHw3KVB1gNJOuRcQfKOPhucEhX1NJzXzgMDnwSCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "loglevel": "^1.9.1"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -17487,6 +17497,19 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/chainforge/react-server/package.json
+++ b/chainforge/react-server/package.json
@@ -20,6 +20,7 @@
     "@mantine/form": "^6.0.11",
     "@mantine/prism": "^6.0.15",
     "@mirai73/bedrock-fm": "^0.4.10",
+    "@mlc-ai/web-llm": "^0.2.84",
     "@reactflow/background": "^11.2.0",
     "@reactflow/controls": "^11.1.11",
     "@reactflow/core": "^11.7.0",

--- a/chainforge/react-server/src/App.tsx
+++ b/chainforge/react-server/src/App.tsx
@@ -112,6 +112,7 @@ import {
   isEdgeChromium,
   isChromium,
   isMobileSafari,
+  isSafari,
 } from "react-device-detect";
 import MultiEvalNode from "./MultiEvalNode";
 import FlowSidebar from "./FlowSidebar";
@@ -125,6 +126,7 @@ const IS_ACCEPTED_BROWSER =
     isChromium ||
     isEdgeChromium ||
     isFirefox ||
+    isSafari ||
     (navigator as any)?.brave !== undefined) &&
   (!isMobile || (isTablet && !isMobileSafari));
 
@@ -1497,6 +1499,7 @@ const App = () => {
           <List.Item>Mozilla Firefox</List.Item>
           <List.Item>Microsoft Edge (Chromium)</List.Item>
           <List.Item>Brave</List.Item>
+          <List.Item>Safari</List.Item>
         </List>
 
         <Text m="xl" size={"11pt"}>
@@ -1677,8 +1680,9 @@ const App = () => {
             variant={colorScheme === "light" ? "gradient" : "filled"}
             color={colorScheme === "light" ? "blue" : "gray"}
             compact
+            style={{ width: "32px", minWidth: "32px", padding: 0 }}
           >
-            <IconSettings size={"90%"} />
+            <IconSettings size={18} />
           </Button>
         </div>
         <div

--- a/chainforge/react-server/src/App.tsx
+++ b/chainforge/react-server/src/App.tsx
@@ -67,6 +67,7 @@ import {
   getDefaultModelFormData,
   getDefaultModelSettings,
 } from "./ModelSettingSchemas";
+import { NativeLLM } from "./backend/models";
 import { v4 as uuid } from "uuid";
 import axios from "axios";
 import LZString from "lz-string";
@@ -169,37 +170,19 @@ const selector = (state: StoreHandles) => ({
 
 // The initial LLM to use when new flows are created, or upon first load
 const INITIAL_LLM = () => {
-  if (!IS_RUNNING_LOCALLY) {
-    // Prefer HF if running on server, as it's free.
-    const falcon7b = {
-      key: uuid(),
-      name: "Mistral-7B",
-      emoji: "🤗",
-      model: "mistralai/Mistral-7B-Instruct-v0.1",
-      base_model: "hf",
-      temp: 1.0,
-      settings: getDefaultModelSettings("hf"),
-      formData: getDefaultModelFormData("hf"),
-    } satisfies LLMSpec;
-    falcon7b.formData.shortname = falcon7b.name;
-    falcon7b.formData.model = falcon7b.model;
-    return falcon7b;
-  } else {
-    // Prefer OpenAI for majority of local users.
-    const chatgpt = {
-      key: uuid(),
-      name: "GPT-4o-mini",
-      emoji: "🤖",
-      model: "gpt-4o-mini",
-      base_model: "gpt-4",
-      temp: 1.0,
-      settings: getDefaultModelSettings("gpt-4"),
-      formData: getDefaultModelFormData("gpt-4"),
-    } satisfies LLMSpec;
-    chatgpt.formData.shortname = chatgpt.name;
-    chatgpt.formData.model = chatgpt.model;
-    return chatgpt;
-  }
+  const qwenWebLLM = {
+    key: uuid(),
+    name: "Qwen2.5 0.5B",
+    emoji: "🌐",
+    model: NativeLLM.WebLLM_Qwen2_5_0_5B,
+    base_model: "webllm",
+    temp: 0.7,
+    settings: getDefaultModelSettings("webllm"),
+    formData: getDefaultModelFormData("webllm"),
+  } satisfies LLMSpec;
+  qwenWebLLM.formData.shortname = qwenWebLLM.name;
+  qwenWebLLM.formData.model = qwenWebLLM.model;
+  return qwenWebLLM;
 };
 
 const nodeTypes = {

--- a/chainforge/react-server/src/BaseNode.tsx
+++ b/chainforge/react-server/src/BaseNode.tsx
@@ -152,10 +152,13 @@ export const BaseNode: React.FC<BaseNodeProps> = ({
                 {icon}&nbsp;{text}
               </Menu.Item>
             ))}
-          <Menu.Item key="duplicate" onClick={() => {
-            handleDuplicateNode();
-            setContextMenuOpened(false);
-          }}>
+          <Menu.Item
+            key="duplicate"
+            onClick={() => {
+              handleDuplicateNode();
+              setContextMenuOpened(false);
+            }}
+          >
             <IconCopy size="10pt" />
             &nbsp;Duplicate Node
           </Menu.Item>
@@ -163,9 +166,9 @@ export const BaseNode: React.FC<BaseNodeProps> = ({
             <Menu.Item
               key="favorite"
               onClick={() => {
-              setFavoriteNameModalOpen(true);
-              setContextMenuOpened(false);
-            }}
+                setFavoriteNameModalOpen(true);
+                setContextMenuOpened(false);
+              }}
             >
               <IconHeart
                 size="12pt"
@@ -175,10 +178,13 @@ export const BaseNode: React.FC<BaseNodeProps> = ({
               &nbsp;Favorite Node
             </Menu.Item>
           )}
-          <Menu.Item key="delete" onClick={() => {
-            handleRemoveNode();
-            setContextMenuOpened(false);
-          }}>
+          <Menu.Item
+            key="delete"
+            onClick={() => {
+              handleRemoveNode();
+              setContextMenuOpened(false);
+            }}
+          >
             <IconX size="10pt" />
             &nbsp;Delete Node
           </Menu.Item>

--- a/chainforge/react-server/src/BaseNode.tsx
+++ b/chainforge/react-server/src/BaseNode.tsx
@@ -152,14 +152,20 @@ export const BaseNode: React.FC<BaseNodeProps> = ({
                 {icon}&nbsp;{text}
               </Menu.Item>
             ))}
-          <Menu.Item key="duplicate" onClick={handleDuplicateNode}>
+          <Menu.Item key="duplicate" onClick={() => {
+            handleDuplicateNode();
+            setContextMenuOpened(false);
+          }}>
             <IconCopy size="10pt" />
             &nbsp;Duplicate Node
           </Menu.Item>
           {IS_RUNNING_LOCALLY && (
             <Menu.Item
               key="favorite"
-              onClick={() => setFavoriteNameModalOpen(true)}
+              onClick={() => {
+              setFavoriteNameModalOpen(true);
+              setContextMenuOpened(false);
+            }}
             >
               <IconHeart
                 size="12pt"
@@ -169,7 +175,10 @@ export const BaseNode: React.FC<BaseNodeProps> = ({
               &nbsp;Favorite Node
             </Menu.Item>
           )}
-          <Menu.Item key="delete" onClick={handleRemoveNode}>
+          <Menu.Item key="delete" onClick={() => {
+            handleRemoveNode();
+            setContextMenuOpened(false);
+          }}>
             <IconX size="10pt" />
             &nbsp;Delete Node
           </Menu.Item>

--- a/chainforge/react-server/src/CodeEvaluatorNode.tsx
+++ b/chainforge/react-server/src/CodeEvaluatorNode.tsx
@@ -48,6 +48,7 @@ import {
   toStandardResponseFormat,
 } from "./backend/utils";
 import InspectFooter from "./InspectFooter";
+import ResizeHandle from "./ResizeHandle";
 import { escapeBraces } from "./backend/template";
 import LLMResponseInspectorDrawer from "./LLMResponseInspectorDrawer";
 import { AIGenCodeEvaluatorPopover } from "./AiPopover";
@@ -243,6 +244,8 @@ export const CodeEvaluatorComponent = forwardRef<
   const [codeTextOnLastRun, setCodeTextOnLastRun] = useState<boolean | string>(
     false,
   );
+  const aceEditorRef = useRef<any>(null);
+  const aceContainerRef = useRef<HTMLDivElement>(null);
 
   // Color theme
   const { colorScheme } = useMantineColorScheme();
@@ -352,7 +355,11 @@ export const CodeEvaluatorComponent = forwardRef<
   return (
     <div className="core-mirror-field">
       {showUserInstruction ? code_instruct_header : <></>}
-      <div className="ace-editor-container nodrag">
+      <div
+        ref={aceContainerRef}
+        className="ace-editor-container nodrag"
+        style={{ minWidth: "310px", minHeight: "60px", height: "100px" }}
+      >
         <AceEditor
           mode={progLang}
           theme={colorScheme === "light" ? "xcode" : "monokai"}
@@ -361,15 +368,18 @@ export const CodeEvaluatorComponent = forwardRef<
           name={"aceeditor_" + id}
           editorProps={{ $blockScrolling: true }}
           width="100%"
-          height="100px"
-          style={{ minWidth: "310px" }}
+          height="100%"
           setOptions={{ useWorker: false }}
           tabSize={2}
           onLoad={(editorInstance) => {
-            // Make Ace Editor div resizeable.
-            editorInstance.container.style.resize = "both";
-            document.addEventListener("mouseup", () => editorInstance.resize());
+            aceEditorRef.current = editorInstance;
           }}
+        />
+        <ResizeHandle
+          targetRef={aceContainerRef}
+          minWidth={310}
+          minHeight={60}
+          onResizeEnd={() => aceEditorRef.current?.resize()}
         />
       </div>
     </div>

--- a/chainforge/react-server/src/InspectorNode.tsx
+++ b/chainforge/react-server/src/InspectorNode.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 import { Handle, Position } from "reactflow";
 import useStore from "./store";
 import BaseNode from "./BaseNode";
@@ -7,6 +7,7 @@ import LLMResponseInspector, { exportToExcel } from "./LLMResponseInspector";
 import { grabResponses } from "./backend/backend";
 import { LLMResponse } from "./backend/typing";
 import { AlertModalContext } from "./AlertModal";
+import ResizeHandle from "./ResizeHandle";
 
 export interface InspectorNodeProps {
   data: {
@@ -28,6 +29,7 @@ const InspectorNode: React.FC<InspectorNodeProps> = ({ data, id }) => {
   const inputEdgesForNode = useStore((state) => state.inputEdgesForNode);
   const setDataPropsForNode = useStore((state) => state.setDataPropsForNode);
   const showAlert = useContext(AlertModalContext);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleOnConnect = () => {
     // For some reason, 'on connect' is called twice upon connection.
@@ -89,6 +91,7 @@ const InspectorNode: React.FC<InspectorNodeProps> = ({ data, id }) => {
         ]}
       />
       <div
+        ref={containerRef}
         className="inspect-response-container nowheel nodrag"
         style={{ marginTop: "-8pt" }}
       >
@@ -97,6 +100,7 @@ const InspectorNode: React.FC<InspectorNodeProps> = ({ data, id }) => {
           isOpen={true}
           wideFormat={false}
         />
+        <ResizeHandle targetRef={containerRef} minWidth={150} minHeight={270} />
       </div>
       <Handle
         type="target"

--- a/chainforge/react-server/src/LLMItemButtonGroup.tsx
+++ b/chainforge/react-server/src/LLMItemButtonGroup.tsx
@@ -47,37 +47,40 @@ export default function LLMItemButtonGroup({
   hideTrashIcon,
 }: LLMItemButtonGroupProps) {
   return (
-    <div>
-      <Group
-        position="right"
-        spacing="xs"
-        style={{ float: "right", height: "20px" }}
-      >
-        <GatheringResponsesRingProgress progress={ringProgress} />
-        {hideTrashIcon ? (
-          <></>
-        ) : (
-          <Button
-            onClick={onClickTrash}
-            size="xs"
-            variant="light"
-            compact
-            color="red"
-            style={{ padding: "0px" }}
-          >
-            <IconTrash size={"95%"} />
-          </Button>
-        )}
+    <Group
+      spacing="xs"
+      style={{ flexShrink: 0, width: "fit-content", alignItems: "center" }}
+    >
+      <GatheringResponsesRingProgress progress={ringProgress} />
+      {hideTrashIcon ? (
+        <></>
+      ) : (
         <Button
-          onClick={onClickSettings}
+          onClick={onClickTrash}
           size="xs"
           variant="light"
-          color="blue"
           compact
+          color="red"
+          style={{
+            padding: "0px",
+            width: "28px",
+            minWidth: "28px",
+            height: "28px",
+          }}
         >
-          <IconSettings size={"110%"} />
+          <IconTrash size={16} />
         </Button>
-      </Group>
-    </div>
+      )}
+      <Button
+        onClick={onClickSettings}
+        size="xs"
+        variant="light"
+        color="blue"
+        compact
+        style={{ width: "28px", minWidth: "28px", height: "28px" }}
+      >
+        <IconSettings size={16} />
+      </Button>
+    </Group>
   );
 }

--- a/chainforge/react-server/src/LLMListComponent.tsx
+++ b/chainforge/react-server/src/LLMListComponent.tsx
@@ -24,6 +24,7 @@ import ModelSettingsModal, {
   ModelSettingsModalRef,
 } from "./ModelSettingsModal";
 import { getDefaultModelSettings } from "./ModelSettingSchemas";
+import { NativeLLM } from "./backend/models";
 import useStore, { initLLMProviders, initLLMProviderMenu } from "./store";
 import { Dict, JSONCompatible, LLMGroup, LLMSpec } from "./backend/typing";
 import { ContextMenuItemOptions } from "mantine-contextmenu/dist/types";
@@ -31,9 +32,9 @@ import { deepcopy, ensureUniqueName } from "./backend/utils";
 import NestedMenu, { NestedMenuItemProps } from "./NestedMenu";
 
 // The LLM(s) to include by default on a PromptNode whenever one is created.
-// Defaults to a cheap non-reasoning OpenAI model.
+// Defaults to an in-browser Qwen 2.5 model.
 const DEFAULT_INIT_LLMS = [
-  initLLMProviders.find((m) => m.model === "gpt-4o-mini")!,
+  initLLMProviders.find((m) => m.model === NativeLLM.WebLLM_Qwen2_5_0_5B)!,
 ];
 
 // Helper funcs
@@ -499,7 +500,6 @@ export const LLMListContainer = forwardRef<
             items={menuItems}
             button={(closeMenu) => (
               <button
-                style={_bgStyle}
                 onClick={() => {
                   closeMenu();
                 }}

--- a/chainforge/react-server/src/LLMListItem.tsx
+++ b/chainforge/react-server/src/LLMListItem.tsx
@@ -56,7 +56,7 @@ const CardHeader = styled.div`
   font-family: -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   text-align: start;
-  float: left;
+  flex: 1;
   margin-top: 1px;
 `;
 const TemperatureStatus = styled.span`
@@ -64,15 +64,13 @@ const TemperatureStatus = styled.span`
 `;
 
 export const DragItem = styled.div`
-  padding: 6px;
+  padding: 3px 6px;
   border-radius: 6px;
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.12),
     0 1px 2px rgba(0, 0, 0, 0.24);
   margin: 0 0 8px 0;
-  display: grid;
-  grid-gap: 20px;
-  flex-direction: column;
+  overflow: hidden;
 `;
 
 export interface LLMListItemProps {
@@ -113,9 +111,16 @@ const LLMListItem: React.FC<LLMListItemProps> = ({
       {...provided.dragHandleProps}
     >
       <div>
-        <CardHeader>
-          {item.emoji}&nbsp;{item.name}
-          {/* {temperature !== undefined ? (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <CardHeader>
+            {item.emoji}&nbsp;{item.name}
+            {/* {temperature !== undefined ? (
             <Tooltip label={"temp = " + (temperature || "0")} withArrow>
               <TemperatureStatus style={{ color: tempColor }}>
                 &nbsp;
@@ -134,15 +139,16 @@ const LLMListItem: React.FC<LLMListItemProps> = ({
           ) : (
             <></>
           )} */}
-        </CardHeader>
-        <LLMItemButtonGroup
-          onClickTrash={() =>
-            removeCallback && removeCallback(item.key ?? "undefined")
-          }
-          ringProgress={progress}
-          onClickSettings={onClickSettings}
-          hideTrashIcon={hideTrashIcon}
-        />
+          </CardHeader>
+          <LLMItemButtonGroup
+            onClickTrash={() =>
+              removeCallback && removeCallback(item.key ?? "undefined")
+            }
+            ringProgress={progress}
+            onClickSettings={onClickSettings}
+            hideTrashIcon={hideTrashIcon}
+          />
+        </div>
       </div>
     </DragItem>
   );
@@ -172,27 +178,35 @@ export const LLMListItemClone: React.FC<LLMListItemProps> = ({
       snapshot={snapshot}
     >
       <div>
-        <CardHeader>
-          {item.emoji}&nbsp;{item.name}
-          {temperature !== undefined ? (
-            <TemperatureStatus style={{ color: tempColor }}>
-              &nbsp;
-              <IconTemperature
-                size={14}
-                stroke={2}
-                style={{
-                  position: "relative",
-                  top: "2px",
-                  marginRight: "-3px",
-                }}
-              />
-              :{temperature !== undefined ? temperature : ""}
-            </TemperatureStatus>
-          ) : (
-            <></>
-          )}
-        </CardHeader>
-        <LLMItemButtonGroup hideTrashIcon={hideTrashIcon} />
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <CardHeader>
+            {item.emoji}&nbsp;{item.name}
+            {temperature !== undefined ? (
+              <TemperatureStatus style={{ color: tempColor }}>
+                &nbsp;
+                <IconTemperature
+                  size={14}
+                  stroke={2}
+                  style={{
+                    position: "relative",
+                    top: "2px",
+                    marginRight: "-3px",
+                  }}
+                />
+                :{temperature !== undefined ? temperature : ""}
+              </TemperatureStatus>
+            ) : (
+              <></>
+            )}
+          </CardHeader>
+          <LLMItemButtonGroup hideTrashIcon={hideTrashIcon} />
+        </div>
       </div>
     </DragItem>
   );

--- a/chainforge/react-server/src/LLMResponseInspectorDrawer.tsx
+++ b/chainforge/react-server/src/LLMResponseInspectorDrawer.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useRef } from "react";
 import LLMResponseInspector from "./LLMResponseInspector";
 import { LLMResponse } from "./backend/typing";
+import ResizeHandle from "./ResizeHandle";
 
 export interface LLMResponseInspectorDrawerProps {
   jsonResponses: LLMResponse[];
@@ -11,12 +12,15 @@ export default function LLMResponseInspectorDrawer({
   jsonResponses,
   showDrawer,
 }: LLMResponseInspectorDrawerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   return (
     <div
       className="inspect-responses-drawer"
       style={{ display: showDrawer ? "initial" : "none" }}
     >
       <div
+        ref={containerRef}
         className="inspect-response-container nowheel nodrag"
         style={{ margin: "0px 10px 10px 12px" }}
       >
@@ -25,6 +29,7 @@ export default function LLMResponseInspectorDrawer({
           isOpen={showDrawer}
           wideFormat={false}
         />
+        <ResizeHandle targetRef={containerRef} minWidth={150} minHeight={270} />
       </div>
     </div>
   );

--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -472,6 +472,108 @@ const DeepSeekSettings: ModelSettingsDict = {
   postprocessors: ChatGPTSettings.postprocessors,
 };
 
+const MiniMaxSettings: ModelSettingsDict = {
+  fullName: "MiniMax",
+  schema: {
+    type: "object",
+    required: ["shortname"],
+    properties: {
+      shortname: {
+        type: "string",
+        title: "Nickname",
+        description:
+          "Unique identifier to appear in ChainForge. Keep it short.",
+        default: "MiniMax",
+      },
+      model: {
+        type: "string",
+        title: "Model Version",
+        description:
+          "Select a MiniMax model to query. For more details, see the MiniMax API documentation at https://platform.minimaxi.com.",
+        enum: ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+        default: "MiniMax-M2.7",
+        shortname_map: {
+          "MiniMax-M2.7": "M2.7",
+          "MiniMax-M2.7-highspeed": "M2.7-hs",
+        },
+      },
+      system_msg: {
+        type: "string",
+        title: "system_msg",
+        description:
+          "Many conversations begin with a system message to gently instruct the assistant.",
+        default: "You are a helpful assistant.",
+        allow_empty_str: true,
+      },
+      temperature: {
+        type: "number",
+        title: "temperature",
+        description:
+          "What sampling temperature to use, between 0.01 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. Note: MiniMax requires temperature > 0.",
+        default: 0.7,
+        minimum: 0.01,
+        maximum: 1,
+        multipleOf: 0.01,
+      },
+      top_p: {
+        type: "number",
+        title: "top_p",
+        description:
+          "An alternative to sampling with temperature, called nucleus sampling.",
+        default: 1,
+        minimum: 0,
+        maximum: 1,
+        multipleOf: 0.005,
+      },
+      stop: {
+        type: "string",
+        title: "stop sequences",
+        description:
+          'Sequences where the API will stop generating further tokens. Enclose stop sequences in double-quotes "" and use whitespace to separate them.',
+        default: "",
+      },
+      max_tokens: {
+        type: "integer",
+        title: "max_tokens",
+        description:
+          "The maximum number of tokens to generate in the chat completion.",
+      },
+      presence_penalty: {
+        type: "number",
+        title: "presence_penalty",
+        description:
+          "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far.",
+        default: 0,
+        minimum: -2,
+        maximum: 2,
+        multipleOf: 0.005,
+      },
+      frequency_penalty: {
+        type: "number",
+        title: "frequency_penalty",
+        description:
+          "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far.",
+        default: 0,
+        minimum: -2,
+        maximum: 2,
+        multipleOf: 0.005,
+      },
+    },
+  },
+  uiSchema: {
+    ...ChatGPTSettings.uiSchema,
+    model: {
+      "ui:help": "Defaults to MiniMax-M2.7.",
+      "ui:widget": "datalist",
+    },
+    temperature: {
+      "ui:help": "Defaults to 0.7. MiniMax requires temperature > 0.",
+      "ui:widget": "range",
+    },
+  },
+  postprocessors: ChatGPTSettings.postprocessors,
+};
+
 const DalleSettings: ModelSettingsDict = {
   fullName: "Dall-E Image Models (OpenAI)",
   schema: {
@@ -2516,6 +2618,7 @@ export const ModelSettings: Dict<ModelSettingsDict> = {
   "br.meta.llama3": BedrockLlama3Settings,
   together: TogetherChatSettings,
   deepseek: DeepSeekSettings,
+  minimax: MiniMaxSettings,
 };
 
 // A lookup that converts the base_model names into LLMProviders.
@@ -2543,6 +2646,7 @@ export function baseModelToProvider(base_model: string): LLMProvider {
     "br.meta.llama3": LLMProvider.Bedrock,
     together: LLMProvider.Together,
     deepseek: LLMProvider.DeepSeek,
+    minimax: LLMProvider.MiniMax,
   };
   return lookup[base_model] ?? LLMProvider.Custom;
 }
@@ -2564,6 +2668,7 @@ export function getSettingsSchemaForLLM(
     [LLMProvider.Ollama]: OllamaSettings,
     [LLMProvider.Together]: TogetherChatSettings,
     [LLMProvider.DeepSeek]: DeepSeekSettings,
+    [LLMProvider.MiniMax]: MiniMaxSettings,
   };
 
   if (llm_provider === LLMProvider.Custom) return ModelSettings[llm_name];

--- a/chainforge/react-server/src/ModelSettingSchemas.tsx
+++ b/chainforge/react-server/src/ModelSettingSchemas.tsx
@@ -2596,6 +2596,82 @@ BedrockLlama3Settings.uiSchema.model = {
   "ui:help": "Defaults to Llama3Instruct8b",
 };
 
+const WebLLMSettings: ModelSettingsDict = {
+  fullName: "WebLLM (In-browser)",
+  schema: {
+    type: "object",
+    required: ["shortname"],
+    properties: {
+      shortname: {
+        type: "string",
+        title: "Nickname",
+        description:
+          "Unique identifier to appear in ChainForge. Keep it short.",
+        default: "Qwen2.5 0.5B",
+      },
+      model: {
+        type: "string",
+        title: "Model Version",
+        description: "Select a WebLLM model to run fully in-browser (WebGPU).",
+        enum: [NativeLLM.WebLLM_Qwen2_5_0_5B, NativeLLM.WebLLM_SmolLM2_1_7B],
+        default: NativeLLM.WebLLM_Qwen2_5_0_5B,
+      },
+      system_msg: {
+        type: "string",
+        title: "system_msg",
+        description: "Optional system prompt prepended to the conversation.",
+        default: "You are a helpful assistant.",
+        allow_empty_str: true,
+      },
+      temperature: {
+        type: "number",
+        title: "temperature",
+        description: "Sampling temperature for generation.",
+        default: 0.7,
+        minimum: 0,
+        maximum: 2,
+        multipleOf: 0.01,
+      },
+      top_p: {
+        type: "number",
+        title: "top_p",
+        description: "Nucleus sampling parameter.",
+        default: 1,
+        minimum: 0,
+        maximum: 1,
+        multipleOf: 0.01,
+      },
+      max_tokens: {
+        type: "integer",
+        title: "max_tokens",
+        description: "Maximum output tokens per generation.",
+        default: 512,
+        minimum: 1,
+      },
+    },
+  },
+  uiSchema: {
+    "ui:submitButtonOptions": UI_SUBMIT_BUTTON_SPEC,
+    shortname: {
+      "ui:autofocus": true,
+    },
+    model: {
+      "ui:widget": "datalist",
+      "ui:help": "Defaults to Qwen2.5-0.5B.",
+    },
+    system_msg: {
+      "ui:widget": "textarea",
+    },
+    temperature: {
+      "ui:widget": "range",
+    },
+    top_p: {
+      "ui:widget": "range",
+    },
+  },
+  postprocessors: {},
+};
+
 // A lookup table indexed by base_model.
 export const ModelSettings: Dict<ModelSettingsDict> = {
   "gpt-3.5-turbo": ChatGPTSettings,
@@ -2619,6 +2695,7 @@ export const ModelSettings: Dict<ModelSettingsDict> = {
   together: TogetherChatSettings,
   deepseek: DeepSeekSettings,
   minimax: MiniMaxSettings,
+  webllm: WebLLMSettings,
 };
 
 // A lookup that converts the base_model names into LLMProviders.
@@ -2647,6 +2724,7 @@ export function baseModelToProvider(base_model: string): LLMProvider {
     together: LLMProvider.Together,
     deepseek: LLMProvider.DeepSeek,
     minimax: LLMProvider.MiniMax,
+    webllm: LLMProvider.WebLLM,
   };
   return lookup[base_model] ?? LLMProvider.Custom;
 }
@@ -2669,6 +2747,7 @@ export function getSettingsSchemaForLLM(
     [LLMProvider.Together]: TogetherChatSettings,
     [LLMProvider.DeepSeek]: DeepSeekSettings,
     [LLMProvider.MiniMax]: MiniMaxSettings,
+    [LLMProvider.WebLLM]: WebLLMSettings,
   };
 
   if (llm_provider === LLMProvider.Custom) return ModelSettings[llm_name];

--- a/chainforge/react-server/src/ResizeHandle.tsx
+++ b/chainforge/react-server/src/ResizeHandle.tsx
@@ -1,0 +1,98 @@
+/**
+ * A custom resize handle for use inside ReactFlow nodes.
+ *
+ * Safari does not support CSS `resize: both` on elements inside CSS
+ * `transform`-ed parents (which is how ReactFlow positions nodes).
+ * This component replaces that native handle with a JS-driven one.
+ *
+ * Usage:
+ *   <div ref={containerRef} style={{ position: "relative", overflow: "auto", width: 300, height: 200 }}>
+ *     ...content...
+ *     <ResizeHandle targetRef={containerRef} />
+ *   </div>
+ */
+import React, { useCallback, useRef } from "react";
+
+interface ResizeHandleProps {
+  targetRef: React.RefObject<HTMLElement>;
+  minWidth?: number;
+  minHeight?: number;
+  /** Called once when the drag ends. */
+  onResizeEnd?: () => void;
+}
+
+export default function ResizeHandle({
+  targetRef,
+  minWidth = 100,
+  minHeight = 80,
+  onResizeEnd,
+}: ResizeHandleProps) {
+  const startPos = useRef<{
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  } | null>(null);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const el = targetRef.current;
+      if (!el) return;
+      startPos.current = {
+        x: e.clientX,
+        y: e.clientY,
+        w: el.offsetWidth,
+        h: el.offsetHeight,
+      };
+      (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
+    },
+    [targetRef],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!startPos.current) return;
+      e.stopPropagation();
+      const el = targetRef.current;
+      if (!el) return;
+      const dx = e.clientX - startPos.current.x;
+      const dy = e.clientY - startPos.current.y;
+      el.style.width = `${Math.max(minWidth, startPos.current.w + dx)}px`;
+      el.style.height = `${Math.max(minHeight, startPos.current.h + dy)}px`;
+    },
+    [targetRef, minWidth, minHeight],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      startPos.current = null;
+      if (onResizeEnd) onResizeEnd();
+    },
+    [onResizeEnd],
+  );
+
+  return (
+    <div
+      title="Drag to resize"
+      style={{
+        position: "absolute",
+        bottom: 0,
+        right: 0,
+        width: "16px",
+        height: "16px",
+        cursor: "nwse-resize",
+        zIndex: 10,
+        // Render a subtle triangular grip (matches native resize handle look)
+        background:
+          "linear-gradient(135deg, transparent 50%, rgba(120,120,120,0.35) 50%)",
+        borderBottomRightRadius: "4px",
+      }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    />
+  );
+}

--- a/chainforge/react-server/src/TabularDataNode.tsx
+++ b/chainforge/react-server/src/TabularDataNode.tsx
@@ -30,6 +30,7 @@ import {
 import TemplateHooks from "./TemplateHooksComponent";
 import BaseNode from "./BaseNode";
 import NodeLabel from "./NodeLabelComponent";
+import ResizeHandle from "./ResizeHandle";
 import { AlertModalContext } from "./AlertModal";
 import RenameValueModal, { RenameValueModalRef } from "./RenameValueModal";
 import useStore from "./store";
@@ -815,6 +816,7 @@ const TabularDataNode: React.FC<TabularDataNodeProps> = ({ data, id }) => {
           handleInsertColumn={handleInsertColumn}
           handleRenameColumn={openRenameColumnModal}
         />
+        <ResizeHandle targetRef={ref} minWidth={200} minHeight={100} />
       </div>
 
       <div className="tabular-data-footer">

--- a/chainforge/react-server/src/VisNode.tsx
+++ b/chainforge/react-server/src/VisNode.tsx
@@ -18,6 +18,7 @@ import useStore, { colorPalettes } from "./store";
 import Plot from "react-plotly.js";
 import BaseNode from "./BaseNode";
 import NodeLabel from "./NodeLabelComponent";
+import ResizeHandle from "./ResizeHandle";
 import PlotLegend from "./PlotLegend";
 import {
   cleanMetavarsFilterFunc,
@@ -1400,7 +1401,11 @@ export const VisView = forwardRef<VisViewRef, VisViewProps>(
         <div
           className="nodrag"
           ref={setPlotDivRef}
-          style={{ minWidth: "150px", minHeight: "100px" }}
+          style={{
+            minWidth: "150px",
+            minHeight: "100px",
+            position: "relative",
+          }}
         >
           {plotlySpec && plotlySpec.length > 0 ? <></> : placeholderText}
           <Plot
@@ -1416,6 +1421,7 @@ export const VisView = forwardRef<VisViewRef, VisViewProps>(
             }}
           />
           {plotLegend ?? <></>}
+          <ResizeHandle targetRef={plotDivRef} minWidth={150} minHeight={100} />
         </div>
       </>
     );

--- a/chainforge/react-server/src/backend/__test__/minimax.test.ts
+++ b/chainforge/react-server/src/backend/__test__/minimax.test.ts
@@ -1,0 +1,359 @@
+/*
+ * @jest-environment jsdom
+ */
+
+// Pre-existing test infra issues in this repo (8 of 9 test suites fail):
+// 1. cache.ts calls APP_IS_RUNNING_LOCALLY() at module load before `let` var is init
+// 2. @google/genai uses ESM syntax not supported by Jest/CRA
+// 3. pyodide/exec-py.js uses import.meta.url not supported outside ESM
+// Mock these to allow our tests to load.
+jest.mock("../cache", () => ({
+  __esModule: true,
+  default: class StorageCache {
+    static getInstance() {
+      return new StorageCache();
+    }
+  },
+}));
+jest.mock("@google/genai", () => ({ GoogleGenAI: jest.fn() }));
+jest.mock("@azure/openai", () => ({
+  AzureKeyCredential: jest.fn(),
+  OpenAIClient: jest.fn(),
+}));
+jest.mock("../pyodide/exec-py", () => ({ execPy: jest.fn() }));
+jest.mock("../../store", () => ({
+  __esModule: true,
+  default: { getState: () => ({ AvailableLLMs: [], setAvailableLLMs: jest.fn() }) },
+}));
+
+import {
+  call_minimax,
+  extract_responses,
+  set_api_keys,
+} from "../utils";
+import {
+  LLMProvider,
+  NativeLLM,
+  getProvider,
+  getEnumName,
+  RATE_LIMIT_BY_PROVIDER,
+} from "../models";
+import { expect, test, describe, beforeAll } from "@jest/globals";
+import {
+  ModelSettings,
+  baseModelToProvider,
+  getSettingsSchemaForLLM,
+  getTemperatureSpecForModel,
+  getDefaultModelFormData,
+  postProcessFormData,
+} from "../../ModelSettingSchemas";
+
+// ─── Unit Tests ─────────────────────────────────────────────────────────────
+
+describe("MiniMax provider detection", () => {
+  test("NativeLLM enum contains MiniMax models", () => {
+    expect(NativeLLM.MiniMax_M2_7).toBe("MiniMax-M2.7");
+    expect(NativeLLM.MiniMax_M2_7_highspeed).toBe("MiniMax-M2.7-highspeed");
+  });
+
+  test("LLMProvider enum contains MiniMax", () => {
+    expect(LLMProvider.MiniMax).toBe("minimax");
+  });
+
+  test("getProvider identifies MiniMax models", () => {
+    expect(getProvider(NativeLLM.MiniMax_M2_7)).toBe(LLMProvider.MiniMax);
+    expect(getProvider(NativeLLM.MiniMax_M2_7_highspeed)).toBe(
+      LLMProvider.MiniMax,
+    );
+  });
+
+  test("getEnumName returns MiniMax enum names", () => {
+    expect(getEnumName(NativeLLM, "MiniMax-M2.7")).toBe("MiniMax_M2_7");
+    expect(getEnumName(NativeLLM, "MiniMax-M2.7-highspeed")).toBe(
+      "MiniMax_M2_7_highspeed",
+    );
+  });
+
+  test("MiniMax has rate limit configured", () => {
+    expect(RATE_LIMIT_BY_PROVIDER[LLMProvider.MiniMax]).toBe(1000);
+  });
+});
+
+describe("MiniMax settings schema", () => {
+  test("ModelSettings contains minimax entry", () => {
+    expect(ModelSettings).toHaveProperty("minimax");
+    expect(ModelSettings.minimax.fullName).toBe("MiniMax");
+  });
+
+  test("baseModelToProvider maps minimax correctly", () => {
+    expect(baseModelToProvider("minimax")).toBe(LLMProvider.MiniMax);
+  });
+
+  test("getSettingsSchemaForLLM returns MiniMax schema", () => {
+    const schema = getSettingsSchemaForLLM("MiniMax-M2.7");
+    expect(schema).toBeDefined();
+    expect(schema?.fullName).toBe("MiniMax");
+  });
+
+  test("MiniMax schema has required model properties", () => {
+    const schema = ModelSettings.minimax.schema;
+    expect(schema.properties).toHaveProperty("shortname");
+    expect(schema.properties).toHaveProperty("model");
+    expect(schema.properties).toHaveProperty("temperature");
+    expect(schema.properties).toHaveProperty("system_msg");
+    expect(schema.properties).toHaveProperty("top_p");
+    expect(schema.properties).toHaveProperty("max_tokens");
+    expect(schema.properties).toHaveProperty("stop");
+  });
+
+  test("MiniMax model enum includes both models", () => {
+    const modelEnum = ModelSettings.minimax.schema.properties.model.enum;
+    expect(modelEnum).toContain("MiniMax-M2.7");
+    expect(modelEnum).toContain("MiniMax-M2.7-highspeed");
+  });
+
+  test("MiniMax temperature has correct bounds for temp > 0", () => {
+    const tempSpec = ModelSettings.minimax.schema.properties.temperature;
+    expect(tempSpec.minimum).toBe(0.01);
+    expect(tempSpec.maximum).toBe(1);
+    expect(tempSpec.default).toBe(0.7);
+  });
+
+  test("getTemperatureSpecForModel returns correct spec for minimax", () => {
+    const spec = getTemperatureSpecForModel("minimax");
+    expect(spec).toBeDefined();
+    expect(spec?.minimum).toBe(0.01);
+    expect(spec?.maximum).toBe(1);
+    expect(spec?.default).toBe(0.7);
+  });
+
+  test("MiniMax default form data has expected values", () => {
+    const defaults = getDefaultModelFormData(ModelSettings.minimax);
+    expect(defaults.shortname).toBe("MiniMax");
+    expect(defaults.model).toBe("MiniMax-M2.7");
+    expect(defaults.temperature).toBe(0.7);
+    expect(defaults.system_msg).toBe("You are a helpful assistant.");
+  });
+
+  test("MiniMax schema has shortname_map for models", () => {
+    const shortNameMap =
+      ModelSettings.minimax.schema.properties.model.shortname_map;
+    expect(shortNameMap).toBeDefined();
+    expect(shortNameMap["MiniMax-M2.7"]).toBe("M2.7");
+    expect(shortNameMap["MiniMax-M2.7-highspeed"]).toBe("M2.7-hs");
+  });
+
+  test("postProcessFormData strips model and shortname", () => {
+    const formData = {
+      shortname: "MiniMax",
+      model: "MiniMax-M2.7",
+      temperature: 0.7,
+      system_msg: "You are a helpful assistant.",
+    };
+    const processed = postProcessFormData(ModelSettings.minimax, formData);
+    expect(processed).not.toHaveProperty("shortname");
+    expect(processed).not.toHaveProperty("model");
+    expect(processed).toHaveProperty("temperature");
+    expect(processed).toHaveProperty("system_msg");
+  });
+
+  test("MiniMax stop postprocessor parses quoted strings", () => {
+    const postprocessors = ModelSettings.minimax.postprocessors;
+    expect(postprocessors).toBeDefined();
+    if (postprocessors?.stop) {
+      const result = postprocessors.stop('"stop1" "stop2"');
+      expect(result).toEqual(["stop1", "stop2"]);
+    }
+  });
+
+  test("MiniMax stop postprocessor handles empty string", () => {
+    const postprocessors = ModelSettings.minimax.postprocessors;
+    if (postprocessors?.stop) {
+      const result = postprocessors.stop("");
+      expect(result).toEqual([]);
+    }
+  });
+});
+
+describe("MiniMax response extraction", () => {
+  test("extract_responses handles OpenAI-compatible MiniMax chat response", () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: { content: "Hello from MiniMax!" },
+          finish_reason: "stop",
+        },
+        {
+          message: { content: "Another response." },
+          finish_reason: "stop",
+        },
+      ],
+    };
+    const responses = extract_responses(
+      mockResponse,
+      NativeLLM.MiniMax_M2_7,
+      LLMProvider.MiniMax,
+    );
+    expect(responses).toHaveLength(2);
+    expect(responses[0]).toBe("Hello from MiniMax!");
+    expect(responses[1]).toBe("Another response.");
+  });
+
+  test("extract_responses handles single choice", () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: { content: "Single response from MiniMax M2.7." },
+          finish_reason: "stop",
+        },
+      ],
+    };
+    const responses = extract_responses(
+      mockResponse,
+      NativeLLM.MiniMax_M2_7_highspeed,
+      LLMProvider.MiniMax,
+    );
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toBe("Single response from MiniMax M2.7.");
+  });
+
+  test("extract_responses handles empty choices", () => {
+    const mockResponse = { choices: [] };
+    const responses = extract_responses(
+      mockResponse,
+      NativeLLM.MiniMax_M2_7,
+      LLMProvider.MiniMax,
+    );
+    expect(responses).toHaveLength(0);
+  });
+
+  test("extract_responses handles function_call in MiniMax response", () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: "",
+            function_call: {
+              name: "get_weather",
+              arguments: '{"city": "Beijing"}',
+            },
+          },
+          finish_reason: "function_call",
+        },
+      ],
+    };
+    const responses = extract_responses(
+      mockResponse,
+      NativeLLM.MiniMax_M2_7,
+      LLMProvider.MiniMax,
+    );
+    expect(responses).toHaveLength(1);
+    expect((responses[0] as string).startsWith("[[FUNCTION]]")).toBe(true);
+  });
+});
+
+describe("MiniMax call_minimax validation", () => {
+  // Note: set_api_keys with empty string does not clear env-sourced keys
+  // (key_is_present returns false for empty strings, so the key is never updated).
+  // This test only works when MINIMAX_API_KEY is not set in the environment.
+  const describeIfNoKey = process.env.MINIMAX_API_KEY
+    ? describe.skip
+    : describe;
+  describeIfNoKey("without env key", () => {
+    test("call_minimax throws when no API key is set", async () => {
+      await expect(
+        call_minimax(
+          "test prompt",
+          NativeLLM.MiniMax_M2_7,
+          1,
+          0.7,
+        ),
+      ).rejects.toThrow("Could not find a MiniMax API key");
+    });
+  });
+});
+
+// ─── Integration Tests ──────────────────────────────────────────────────────
+// These tests require MINIMAX_API_KEY to be set in the environment.
+
+const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+const describeIfKey = MINIMAX_API_KEY
+  ? describe
+  : describe.skip;
+
+describeIfKey("MiniMax API integration tests", () => {
+  beforeAll(() => {
+    if (MINIMAX_API_KEY) {
+      set_api_keys({ MiniMax: MINIMAX_API_KEY });
+    }
+  });
+
+  test(
+    "call_minimax returns valid chat response",
+    async () => {
+      const [query, response] = await call_minimax(
+        "What is 2 + 2? Reply with just the number.",
+        NativeLLM.MiniMax_M2_7,
+        1,
+        0.7,
+      );
+
+      expect(query).toHaveProperty("model");
+      expect(query).toHaveProperty("temperature");
+      expect(query.temperature).toBeGreaterThanOrEqual(0.01);
+
+      expect(response).toHaveProperty("choices");
+      expect(response.choices).toHaveLength(1);
+      expect(response.choices[0]).toHaveProperty("message");
+      expect(typeof response.choices[0].message.content).toBe("string");
+
+      const resps = extract_responses(
+        response,
+        NativeLLM.MiniMax_M2_7,
+        LLMProvider.MiniMax,
+      );
+      expect(resps).toHaveLength(1);
+      expect(typeof resps[0]).toBe("string");
+      expect((resps[0] as string).includes("4")).toBe(true);
+    },
+    60000,
+  );
+
+  test(
+    "call_minimax clamps temperature > 0",
+    async () => {
+      // Pass temperature=0, should be clamped to 0.01
+      const [query] = await call_minimax(
+        "Say hello.",
+        NativeLLM.MiniMax_M2_7,
+        1,
+        0, // zero temperature
+      );
+      // The clamped temperature should be 0.01
+      expect(query.temperature).toBeGreaterThan(0);
+    },
+    30000,
+  );
+
+  test(
+    "call_minimax with system message",
+    async () => {
+      const [query, response] = await call_minimax(
+        "What is your role?",
+        NativeLLM.MiniMax_M2_7,
+        1,
+        0.7,
+        { system_msg: "You are a pirate. Always respond like a pirate." },
+      );
+
+      const resps = extract_responses(
+        response,
+        NativeLLM.MiniMax_M2_7,
+        LLMProvider.MiniMax,
+      );
+      expect(resps).toHaveLength(1);
+      expect(typeof resps[0]).toBe("string");
+    },
+    30000,
+  );
+});

--- a/chainforge/react-server/src/backend/__test__/minimax.test.ts
+++ b/chainforge/react-server/src/backend/__test__/minimax.test.ts
@@ -23,14 +23,12 @@ jest.mock("@azure/openai", () => ({
 jest.mock("../pyodide/exec-py", () => ({ execPy: jest.fn() }));
 jest.mock("../../store", () => ({
   __esModule: true,
-  default: { getState: () => ({ AvailableLLMs: [], setAvailableLLMs: jest.fn() }) },
+  default: {
+    getState: () => ({ AvailableLLMs: [], setAvailableLLMs: jest.fn() }),
+  },
 }));
 
-import {
-  call_minimax,
-  extract_responses,
-  set_api_keys,
-} from "../utils";
+import { call_minimax, extract_responses, set_api_keys } from "../utils";
 import {
   LLMProvider,
   NativeLLM,
@@ -47,6 +45,7 @@ import {
   getDefaultModelFormData,
   postProcessFormData,
 } from "../../ModelSettingSchemas";
+import { Dict } from "../typing";
 
 // ─── Unit Tests ─────────────────────────────────────────────────────────────
 
@@ -139,8 +138,10 @@ describe("MiniMax settings schema", () => {
     const shortNameMap =
       ModelSettings.minimax.schema.properties.model.shortname_map;
     expect(shortNameMap).toBeDefined();
-    expect(shortNameMap["MiniMax-M2.7"]).toBe("M2.7");
-    expect(shortNameMap["MiniMax-M2.7-highspeed"]).toBe("M2.7-hs");
+
+    const shortNameMapDict = shortNameMap as Dict<string>;
+    expect(shortNameMapDict["MiniMax-M2.7"]).toBe("M2.7");
+    expect(shortNameMapDict["MiniMax-M2.7-highspeed"]).toBe("M2.7-hs");
   });
 
   test("postProcessFormData strips model and shortname", () => {
@@ -262,12 +263,7 @@ describe("MiniMax call_minimax validation", () => {
   describeIfNoKey("without env key", () => {
     test("call_minimax throws when no API key is set", async () => {
       await expect(
-        call_minimax(
-          "test prompt",
-          NativeLLM.MiniMax_M2_7,
-          1,
-          0.7,
-        ),
+        call_minimax("test prompt", NativeLLM.MiniMax_M2_7, 1, 0.7),
       ).rejects.toThrow("Could not find a MiniMax API key");
     });
   });
@@ -277,9 +273,7 @@ describe("MiniMax call_minimax validation", () => {
 // These tests require MINIMAX_API_KEY to be set in the environment.
 
 const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
-const describeIfKey = MINIMAX_API_KEY
-  ? describe
-  : describe.skip;
+const describeIfKey = MINIMAX_API_KEY ? describe : describe.skip;
 
 describeIfKey("MiniMax API integration tests", () => {
   beforeAll(() => {
@@ -288,72 +282,60 @@ describeIfKey("MiniMax API integration tests", () => {
     }
   });
 
-  test(
-    "call_minimax returns valid chat response",
-    async () => {
-      const [query, response] = await call_minimax(
-        "What is 2 + 2? Reply with just the number.",
-        NativeLLM.MiniMax_M2_7,
-        1,
-        0.7,
-      );
+  test("call_minimax returns valid chat response", async () => {
+    const [query, response] = await call_minimax(
+      "What is 2 + 2? Reply with just the number.",
+      NativeLLM.MiniMax_M2_7,
+      1,
+      0.7,
+    );
 
-      expect(query).toHaveProperty("model");
-      expect(query).toHaveProperty("temperature");
-      expect(query.temperature).toBeGreaterThanOrEqual(0.01);
+    expect(query).toHaveProperty("model");
+    expect(query).toHaveProperty("temperature");
+    expect(query.temperature).toBeGreaterThanOrEqual(0.01);
 
-      expect(response).toHaveProperty("choices");
-      expect(response.choices).toHaveLength(1);
-      expect(response.choices[0]).toHaveProperty("message");
-      expect(typeof response.choices[0].message.content).toBe("string");
+    expect(response).toHaveProperty("choices");
+    expect(response.choices).toHaveLength(1);
+    expect(response.choices[0]).toHaveProperty("message");
+    expect(typeof response.choices[0].message.content).toBe("string");
 
-      const resps = extract_responses(
-        response,
-        NativeLLM.MiniMax_M2_7,
-        LLMProvider.MiniMax,
-      );
-      expect(resps).toHaveLength(1);
-      expect(typeof resps[0]).toBe("string");
-      expect((resps[0] as string).includes("4")).toBe(true);
-    },
-    60000,
-  );
+    const resps = extract_responses(
+      response,
+      NativeLLM.MiniMax_M2_7,
+      LLMProvider.MiniMax,
+    );
+    expect(resps).toHaveLength(1);
+    expect(typeof resps[0]).toBe("string");
+    expect((resps[0] as string).includes("4")).toBe(true);
+  }, 60000);
 
-  test(
-    "call_minimax clamps temperature > 0",
-    async () => {
-      // Pass temperature=0, should be clamped to 0.01
-      const [query] = await call_minimax(
-        "Say hello.",
-        NativeLLM.MiniMax_M2_7,
-        1,
-        0, // zero temperature
-      );
-      // The clamped temperature should be 0.01
-      expect(query.temperature).toBeGreaterThan(0);
-    },
-    30000,
-  );
+  test("call_minimax clamps temperature > 0", async () => {
+    // Pass temperature=0, should be clamped to 0.01
+    const [query] = await call_minimax(
+      "Say hello.",
+      NativeLLM.MiniMax_M2_7,
+      1,
+      0, // zero temperature
+    );
+    // The clamped temperature should be 0.01
+    expect(query.temperature).toBeGreaterThan(0);
+  }, 30000);
 
-  test(
-    "call_minimax with system message",
-    async () => {
-      const [query, response] = await call_minimax(
-        "What is your role?",
-        NativeLLM.MiniMax_M2_7,
-        1,
-        0.7,
-        { system_msg: "You are a pirate. Always respond like a pirate." },
-      );
+  test("call_minimax with system message", async () => {
+    const [query, response] = await call_minimax(
+      "What is your role?",
+      NativeLLM.MiniMax_M2_7,
+      1,
+      0.7,
+      { system_msg: "You are a pirate. Always respond like a pirate." },
+    );
 
-      const resps = extract_responses(
-        response,
-        NativeLLM.MiniMax_M2_7,
-        LLMProvider.MiniMax,
-      );
-      expect(resps).toHaveLength(1);
-      expect(typeof resps[0]).toBe("string");
-    },
-    30000,
-  );
+    const resps = extract_responses(
+      response,
+      NativeLLM.MiniMax_M2_7,
+      LLMProvider.MiniMax,
+    );
+    expect(resps).toHaveLength(1);
+    expect(typeof resps[0]).toBe("string");
+  }, 30000);
 });

--- a/chainforge/react-server/src/backend/models.ts
+++ b/chainforge/react-server/src/backend/models.ts
@@ -5,6 +5,10 @@ import Bottleneck from "bottleneck";
 import { UserForcedPrematureExit } from "./errors";
 
 export enum NativeLLM {
+  // WebLLM (fully in-browser)
+  WebLLM_Qwen2_5_0_5B = "Qwen2.5-0.5B-Instruct-q4f16_1-MLC",
+  WebLLM_SmolLM2_1_7B = "SmolLM2-1.7B-Instruct-q4f16_1-MLC",
+
   // OpenAI Chat
   OpenAI_ChatGPT = "gpt-3.5-turbo",
   OpenAI_ChatGPT_16k = "gpt-3.5-turbo-16k",
@@ -239,6 +243,7 @@ export function getEnumName(
  * A list of model providers
  */
 export enum LLMProvider {
+  WebLLM = "webllm",
   OpenAI = "openai",
   Azure_OpenAI = "azure",
   Anthropic = "anthropic",
@@ -260,7 +265,8 @@ export enum LLMProvider {
  */
 export function getProvider(llm: LLM): LLMProvider | undefined {
   const llm_name = getEnumName(NativeLLM, llm.toString());
-  if (llm_name?.startsWith("OpenAI")) return LLMProvider.OpenAI;
+  if (llm_name?.startsWith("WebLLM")) return LLMProvider.WebLLM;
+  else if (llm_name?.startsWith("OpenAI")) return LLMProvider.OpenAI;
   else if (llm_name?.startsWith("Azure")) return LLMProvider.Azure_OpenAI;
   else if (llm_name?.startsWith("GEMINI")) return LLMProvider.Google;
   else if (llm_name?.startsWith("HF_")) return LLMProvider.HuggingFace;
@@ -272,6 +278,8 @@ export function getProvider(llm: LLM): LLMProvider | undefined {
   else if (llm_name?.startsWith("DeepSeek")) return LLMProvider.DeepSeek;
   else if (llm_name?.startsWith("MiniMax")) return LLMProvider.MiniMax;
   else if (llm.toString().startsWith("__custom/")) return LLMProvider.Custom;
+  else if (llm.toString().toLowerCase().endsWith("-mlc"))
+    return LLMProvider.WebLLM;
 
   return undefined;
 }
@@ -282,6 +290,8 @@ export function getProvider(llm: LLM): LLMProvider | undefined {
 #   If a model is missing from below, it means we must send and receive only 1 request at a time (synchronous).
 #   The following is only a guideline, and a bit on the conservative side.  */
 export const RATE_LIMIT_BY_MODEL: { [key in LLM]?: number } = {
+  [NativeLLM.WebLLM_Qwen2_5_0_5B]: 120,
+  [NativeLLM.WebLLM_SmolLM2_1_7B]: 120,
   [NativeLLM.OpenAI_ChatGPT]: 1000, // max RPM (API requests per minute)
   [NativeLLM.OpenAI_ChatGPT_0301]: 1000,
   [NativeLLM.OpenAI_ChatGPT_0613]: 1000,
@@ -324,6 +334,7 @@ export const RATE_LIMIT_BY_MODEL: { [key in LLM]?: number } = {
 };
 
 export const RATE_LIMIT_BY_PROVIDER: { [key in LLMProvider]?: number } = {
+  [LLMProvider.WebLLM]: 120, // In-browser inference should be serialized and conservative by default.
   [LLMProvider.OpenAI]: 1000, // Tier 3 pricing limit is 5000 per minute, across most models, we use 1000 to be safe.
   [LLMProvider.Azure_OpenAI]: 1000, // Tier 3 pricing limit is 5000 per minute, across most models, we use 1000 to be safe.
   [LLMProvider.Anthropic]: 25, // Tier 1 pricing limit is 50 per minute, across all models; we halve this, to be safe.
@@ -335,6 +346,9 @@ export const RATE_LIMIT_BY_PROVIDER: { [key in LLMProvider]?: number } = {
 
 // Max concurrent requests. Add to this to further constrain the rate limiter.
 export const MAX_CONCURRENT: { [key in string | NativeLLM]?: number } = {};
+
+MAX_CONCURRENT[NativeLLM.WebLLM_Qwen2_5_0_5B] = 1;
+MAX_CONCURRENT[NativeLLM.WebLLM_SmolLM2_1_7B] = 1;
 
 const DEFAULT_RATE_LIMIT = 100; // RPM for any models not listed above
 

--- a/chainforge/react-server/src/backend/models.ts
+++ b/chainforge/react-server/src/backend/models.ts
@@ -93,6 +93,10 @@ export enum NativeLLM {
   DeepSeek_Chat = "deepseek-chat",
   DeepSeek_Reasoner = "deepseek-reasoner",
 
+  // MiniMax
+  MiniMax_M2_7 = "MiniMax-M2.7",
+  MiniMax_M2_7_highspeed = "MiniMax-M2.7-highspeed",
+
   // Aleph Alpha
   Aleph_Alpha_Luminous_Extended = "luminous-extended",
   Aleph_Alpha_Luminous_ExtendedControl = "luminous-extended-control",
@@ -245,6 +249,7 @@ export enum LLMProvider {
   Bedrock = "bedrock",
   Together = "together",
   DeepSeek = "deepseek",
+  MiniMax = "minimax",
   Custom = "__custom",
 }
 
@@ -265,6 +270,7 @@ export function getProvider(llm: LLM): LLMProvider | undefined {
   else if (llm_name?.startsWith("Bedrock")) return LLMProvider.Bedrock;
   else if (llm_name?.startsWith("Together")) return LLMProvider.Together;
   else if (llm_name?.startsWith("DeepSeek")) return LLMProvider.DeepSeek;
+  else if (llm_name?.startsWith("MiniMax")) return LLMProvider.MiniMax;
   else if (llm.toString().startsWith("__custom/")) return LLMProvider.Custom;
 
   return undefined;
@@ -324,6 +330,7 @@ export const RATE_LIMIT_BY_PROVIDER: { [key in LLMProvider]?: number } = {
   [LLMProvider.Together]: 30, // Paid tier limit is 60 per minute, across all models; we halve this, to be safe.
   [LLMProvider.Google]: 1000, // RPM for Google Gemini models 1.5 is quite generous; at base it is 1000 RPM. If you are using the free version it's 15 RPM, but we can expect most CF users to be using paid (and anyway you can just re-run prompt node until satisfied).
   [LLMProvider.DeepSeek]: 1000, // DeepSeek does not constrain users atm but they might in the future. To be safe we are limiting it to 1000 queries per minute.
+  [LLMProvider.MiniMax]: 1000, // MiniMax API rate limits are generous; 1000 RPM to be safe.
 };
 
 // Max concurrent requests. Add to this to further constrain the rate limiter.

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -168,6 +168,54 @@ let TOGETHER_API_KEY = get_environ("TOGETHER_API_KEY");
 let DEEPSEEK_API_KEY = get_environ("DEEPSEEK_API_KEY");
 let MINIMAX_API_KEY = get_environ("MINIMAX_API_KEY");
 
+let _WEBLLM_MODULE_PROMISE: Promise<any> | undefined;
+let _WEBLLM_ENGINE: any;
+let _WEBLLM_MODEL: string | undefined;
+let _WEBLLM_LOAD_PROMISE: Promise<any> | undefined;
+
+async function get_webllm_module(): Promise<any> {
+  if (!_WEBLLM_MODULE_PROMISE) {
+    _WEBLLM_MODULE_PROMISE = import("@mlc-ai/web-llm");
+  }
+  return _WEBLLM_MODULE_PROMISE;
+}
+
+async function get_webllm_engine(model: string): Promise<any> {
+  if (_WEBLLM_LOAD_PROMISE) await _WEBLLM_LOAD_PROMISE;
+
+  if (_WEBLLM_ENGINE && _WEBLLM_MODEL === model) return _WEBLLM_ENGINE;
+
+  if (_WEBLLM_ENGINE && typeof _WEBLLM_ENGINE.reload === "function") {
+    _WEBLLM_LOAD_PROMISE = _WEBLLM_ENGINE.reload(model);
+    try {
+      await _WEBLLM_LOAD_PROMISE;
+      _WEBLLM_MODEL = model;
+      return _WEBLLM_ENGINE;
+    } finally {
+      _WEBLLM_LOAD_PROMISE = undefined;
+    }
+  }
+
+  const webllm = await get_webllm_module();
+  _WEBLLM_LOAD_PROMISE = webllm.CreateMLCEngine(model, {
+    initProgressCallback: (report: Dict) => {
+      if (report?.text) console.log(`[WebLLM] ${report.text}`);
+    },
+  });
+
+  try {
+    _WEBLLM_ENGINE = await _WEBLLM_LOAD_PROMISE;
+    _WEBLLM_MODEL = model;
+    return _WEBLLM_ENGINE;
+  } catch (e) {
+    _WEBLLM_ENGINE = undefined;
+    _WEBLLM_MODEL = undefined;
+    throw e;
+  } finally {
+    _WEBLLM_LOAD_PROMISE = undefined;
+  }
+}
+
 /**
  * Sets the local API keys for the revelant LLM API(s).
  */
@@ -1715,6 +1763,71 @@ async function call_custom_provider(
   return [query, responses];
 }
 
+async function call_webllm(
+  prompt: string,
+  model: LLM,
+  n = 1,
+  temperature = 1.0,
+  params?: Dict,
+  should_cancel?: () => boolean,
+  images?: string[],
+): Promise<[Dict, Dict]> {
+  if (images && images.length > 0)
+    throw new Error(
+      "WebLLM text models currently do not support image inputs in ChainForge.",
+    );
+
+  const llm_model = model.toString();
+  const engine = await get_webllm_engine(llm_model);
+  const call_params = deepcopy(params) ?? {};
+
+  const chat_history: ChatHistory | undefined = call_params.chat_history;
+  const system_msg: string | undefined =
+    call_params.system_msg !== undefined ? call_params.system_msg : undefined;
+  delete call_params.chat_history;
+  delete call_params.system_msg;
+
+  const messages = construct_chat_history(
+    prompt,
+    undefined,
+    chat_history,
+    system_msg,
+  ).map((m) => ({ role: m.role, content: m.content }));
+
+  const max_tokens = call_params.max_tokens;
+  const top_p = call_params.top_p;
+  delete call_params.max_tokens;
+  delete call_params.top_p;
+
+  const query: Dict = {
+    model: llm_model,
+    n,
+    temperature,
+    messages,
+    ...call_params,
+  };
+
+  const choices: Dict[] = [];
+  while (choices.length < n) {
+    if (should_cancel && should_cancel()) throw new UserForcedPrematureExit();
+
+    const completion = await engine.chat.completions.create({
+      model: llm_model,
+      messages,
+      temperature,
+      ...(max_tokens !== undefined ? { max_tokens } : {}),
+      ...(top_p !== undefined ? { top_p } : {}),
+      ...call_params,
+    });
+
+    if (completion?.choices && completion.choices.length > 0)
+      choices.push(...completion.choices);
+    else throw new Error("WebLLM returned no choices.");
+  }
+
+  return [query, { choices: choices.slice(0, n) }];
+}
+
 /**
  * Switcher that routes the request to the appropriate API call function. If call doesn't exist, throws error.
  */
@@ -1740,7 +1853,8 @@ export async function call_llm(
     if (llm_name.startsWith("dall-e") || llm_name.startsWith("gpt-image"))
       call_api = call_openai_image_gen;
     else call_api = call_chatgpt;
-  } else if (llm_provider === LLMProvider.Azure_OpenAI)
+  } else if (llm_provider === LLMProvider.WebLLM) call_api = call_webllm;
+  else if (llm_provider === LLMProvider.Azure_OpenAI)
     call_api = call_azure_openai;
   else if (llm_provider === LLMProvider.Google) call_api = call_google_ai;
   else if (llm_provider === LLMProvider.Anthropic) call_api = call_anthropic;
@@ -1938,6 +2052,8 @@ export function extract_responses(
       else if (llm_name.includes("davinci") || llm_name.includes("instruct"))
         return _extract_openai_completion_responses(response);
       else return _extract_chatgpt_responses(response);
+    case LLMProvider.WebLLM:
+      return _extract_chatgpt_responses(response);
     case LLMProvider.Azure_OpenAI:
       return _extract_openai_responses(response);
     case LLMProvider.Google:

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -166,6 +166,7 @@ let AWS_SESSION_TOKEN = get_environ("AWS_SESSION_TOKEN");
 let AWS_REGION = get_environ("AWS_REGION");
 let TOGETHER_API_KEY = get_environ("TOGETHER_API_KEY");
 let DEEPSEEK_API_KEY = get_environ("DEEPSEEK_API_KEY");
+let MINIMAX_API_KEY = get_environ("MINIMAX_API_KEY");
 
 /**
  * Sets the local API keys for the revelant LLM API(s).
@@ -201,6 +202,7 @@ export function set_api_keys(api_keys: Dict<string>): void {
   if (key_is_present("AWS_Region")) AWS_REGION = api_keys.AWS_Region;
   if (key_is_present("Together")) TOGETHER_API_KEY = api_keys.Together;
   if (key_is_present("DeepSeek")) DEEPSEEK_API_KEY = api_keys.DeepSeek;
+  if (key_is_present("MiniMax")) MINIMAX_API_KEY = api_keys.MiniMax;
 }
 
 export function get_azure_openai_api_keys(): [
@@ -383,13 +385,14 @@ export async function call_chatgpt(
   BASE_URL?: string,
   API_KEY?: string,
 ): Promise<[Dict, Dict]> {
-  if (!OPENAI_API_KEY)
+  const effectiveKey = API_KEY ?? OPENAI_API_KEY;
+  if (!effectiveKey)
     throw new Error(
       "Could not find an OpenAI API key. Double-check that your API key is set in Settings or in your local environment.",
     );
 
   const configuration = new OpenAIConfig({
-    apiKey: API_KEY ?? OPENAI_API_KEY,
+    apiKey: effectiveKey,
     basePath: BASE_URL ?? OPENAI_BASE_URL ?? undefined,
   });
 
@@ -539,6 +542,41 @@ export async function call_deepseek(
     images,
     "https://api.deepseek.com",
     DEEPSEEK_API_KEY,
+  );
+}
+
+/**
+ * Calls MiniMax models via MiniMax's OpenAI-compatible API.
+ */
+export async function call_minimax(
+  prompt: string,
+  model: LLM,
+  n = 1,
+  temperature = 1.0,
+  params?: Dict,
+  should_cancel?: () => boolean,
+  images?: string[],
+): Promise<[Dict, Dict]> {
+  if (!MINIMAX_API_KEY)
+    throw new Error(
+      "Could not find a MiniMax API key. Double-check that your API key is set in Settings or in your local environment.",
+    );
+
+  console.log(`Querying MiniMax model '${model}' with prompt '${prompt}'...`);
+
+  // MiniMax requires temperature to be strictly greater than 0
+  const clampedTemp = Math.max(temperature, 0.01);
+
+  return await call_chatgpt(
+    prompt,
+    model,
+    n,
+    clampedTemp,
+    params,
+    should_cancel,
+    images,
+    "https://api.minimax.io/v1",
+    MINIMAX_API_KEY,
   );
 }
 
@@ -1714,6 +1752,7 @@ export async function call_llm(
   else if (llm_provider === LLMProvider.Bedrock) call_api = call_bedrock;
   else if (llm_provider === LLMProvider.Together) call_api = call_together;
   else if (llm_provider === LLMProvider.DeepSeek) call_api = call_deepseek;
+  else if (llm_provider === LLMProvider.MiniMax) call_api = call_minimax;
   if (call_api === undefined)
     throw new Error(
       `Adapter for Language model ${llm} and ${llm_provider} not found`,
@@ -1918,6 +1957,8 @@ export function extract_responses(
     case LLMProvider.Together:
       return _extract_openai_responses(response as Dict[]);
     case LLMProvider.DeepSeek:
+      return _extract_openai_responses(response as Dict[]);
+    case LLMProvider.MiniMax:
       return _extract_openai_responses(response as Dict[]);
     default:
       if (

--- a/chainforge/react-server/src/backend/utils.ts
+++ b/chainforge/react-server/src/backend/utils.ts
@@ -1149,7 +1149,7 @@ export async function call_huggingface(
   const url =
     using_custom_model_endpoint && params?.custom_model.startsWith("https:")
       ? params.custom_model
-      : `https://api-inference.huggingface.co/models/${
+      : `https://api-inference.huggingface.co/inference-endpoint/${
           using_custom_model_endpoint ? params?.custom_model.trim() : model
         }`;
 

--- a/chainforge/react-server/src/store.tsx
+++ b/chainforge/react-server/src/store.tsx
@@ -276,6 +276,26 @@ export const initLLMProviderMenu: (LLMSpec | LLMGroup)[] = [
     ],
   },
   {
+    group: "MiniMax",
+    emoji: "🔮",
+    items: [
+      {
+        name: "MiniMax M2.7",
+        emoji: "🔮",
+        model: "MiniMax-M2.7",
+        base_model: "minimax",
+        temp: 0.7,
+      },
+      {
+        name: "MiniMax M2.7 Highspeed",
+        emoji: "⚡",
+        model: "MiniMax-M2.7-highspeed",
+        base_model: "minimax",
+        temp: 0.7,
+      },
+    ],
+  },
+  {
     group: "HuggingFace",
     emoji: "🤗",
     items: [

--- a/chainforge/react-server/src/store.tsx
+++ b/chainforge/react-server/src/store.tsx
@@ -98,6 +98,26 @@ const refreshableOutputNodeTypes = new Set([
 
 export const initLLMProviderMenu: (LLMSpec | LLMGroup)[] = [
   {
+    group: "In-browser LLMs",
+    emoji: "🌐",
+    items: [
+      {
+        name: "Qwen2.5 0.5B",
+        emoji: "🌐",
+        model: NativeLLM.WebLLM_Qwen2_5_0_5B,
+        base_model: "webllm",
+        temp: 0.7,
+      },
+      {
+        name: "SmolLM2 1.7B",
+        emoji: "🌐",
+        model: NativeLLM.WebLLM_SmolLM2_1_7B,
+        base_model: "webllm",
+        temp: 0.7,
+      },
+    ],
+  },
+  {
     group: "OpenAI",
     emoji: "🤖",
     items: [

--- a/chainforge/react-server/src/styles.css
+++ b/chainforge/react-server/src/styles.css
@@ -384,7 +384,7 @@ html[data-mantine-color-scheme="dark"] .eval-inspect-response-footer button {
   } */
 
 .ace-editor-container {
-  resize: vertical;
+  position: relative;
 }
 
 .vis-node {
@@ -396,7 +396,7 @@ html[data-mantine-color-scheme="dark"] .eval-inspect-response-footer button {
 .plotly-vis {
   width: 100%;
   height: 100%;
-  resize: both;
+  position: relative;
   overflow: auto;
 }
 .plot-legend {
@@ -483,7 +483,7 @@ html[data-mantine-color-scheme="dark"] .settings-var-inline {
   height: 200px;
   max-width: 1150px;
   max-height: 750px;
-  resize: both;
+  position: relative;
 }
 .inspect-modal-response-container .response-var-header {
   padding: 10px;
@@ -834,7 +834,7 @@ html[data-mantine-color-scheme="dark"] .comment-node textarea {
   min-width: 280px;
 }
 .tabular-data-container {
-  resize: both;
+  position: relative;
   overflow: auto;
   /* max-width: 800px; */
   width: 400px;

--- a/chainforge/react-server/src/styles.css
+++ b/chainforge/react-server/src/styles.css
@@ -1030,6 +1030,10 @@ html[data-mantine-color-scheme="dark"] .add-text-field-btn button:active {
   height: 20px;
 }
 .add-llm-model-btn button {
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: none;
+  background-color: transparent;
   border-style: solid;
   border-color: #777;
   border-width: 1pt;

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name="chainforge",
-    version="0.3.6.4",
+    version="0.3.6.5",
     packages=find_packages(),
     author="Ian Arawjo",
     description="A Visual Programming Environment for Prompt Engineering",


### PR DESCRIPTION
This adds in-browser LLMs using WebLLM. LLMs will one-time download to your browser cache, and then run entirely locally. We included two options by default for their size and on-device performance. 

The in-browser quantized Qwen2.5 0.5B is now the default model when PromptNodes are added. We think most devices today will be able to run this model, which is ~1GB download and once downloaded, runs fast. 

We also unblocked Safari support—it is now 3 years since ChainForge originally released, and the current version of Safari has gained support for the features blocking its access previously. We needed to tweak some things regarding CSS and resize handlers especially (added a new `ResizeHandler` class for cross-browser consistency). If you still have problems, please let us know. 